### PR TITLE
Dispatch input events when test typing

### DIFF
--- a/packages/renderer-process/src/parts/TestFrameWork/ElementActions.ts
+++ b/packages/renderer-process/src/parts/TestFrameWork/ElementActions.ts
@@ -45,6 +45,13 @@ export const hover = (element, options) => {
 
 export const type = (element, options) => {
   element.value = options.text
+  const event = new InputEvent('input', {
+    bubbles: true,
+    cancelable: true,
+    data: options.text,
+    inputType: 'insertText',
+  })
+  element.dispatchEvent(event)
 }
 
 export const keyboardEvent = (element, eventType, options) => {

--- a/packages/renderer-process/test/TestFrameWork.test.ts
+++ b/packages/renderer-process/test/TestFrameWork.test.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import { beforeEach, expect, test } from '@jest/globals'
+import * as ElementActions from '../src/parts/TestFrameWork/ElementActions.ts'
 import * as TestFrameWork from '../src/parts/TestFrameWork/TestFrameWork.ts'
 
 beforeEach(() => {
@@ -24,4 +25,18 @@ test('showTestResults updates existing results element', () => {
   const elements = document.querySelectorAll('.TestResults')
   expect(elements).toHaveLength(1)
   expect(elements[0]?.textContent).toBe('[{"name":"sample.js","status":"fail","error":"x","start":0,"end":1}]')
+})
+
+test('type dispatches input event', () => {
+  const input = document.createElement('input')
+  const events: Event[] = []
+  input.addEventListener('input', (event) => {
+    events.push(event)
+  })
+
+  ElementActions.type(input, { text: 'hello' })
+
+  expect(input.value).toBe('hello')
+  expect(events).toHaveLength(1)
+  expect(events[0]).toBeInstanceOf(InputEvent)
 })


### PR DESCRIPTION
## Summary
- Dispatch a bubbling `input` event from `ElementActions.type()` after assigning the typed value.
- Add coverage proving the test typing helper notifies input listeners.

## Verification
- `cd packages/renderer-process && npm test -- TestFrameWork.test.ts --coverage=false`
- `npm run build` completed; it still reports the existing KeyBindings export warnings.