### PR TITLE
fix: use native open file picker

### DIFF
--- a/packages/renderer-process/src/parts/FilePicker/FilePicker.ts
+++ b/packages/renderer-process/src/parts/FilePicker/FilePicker.ts
@@ -5,7 +5,7 @@ export const showDirectoryPicker = (options) => {
 
 export const showFilePicker = (options) => {
   // @ts-expect-error
-  return window.showFilePicker(options)
+  return window.showOpenFilePicker(options)
 }
 
 export const showSaveFilePicker = (options) => {

--- a/packages/renderer-process/test/FilePicker.test.ts
+++ b/packages/renderer-process/test/FilePicker.test.ts
@@ -9,7 +9,7 @@ beforeAll(() => {
   // @ts-ignore
   window.showDirectoryPicker = jest.fn()
   // @ts-ignore
-  window.showFilePicker = jest.fn()
+  window.showOpenFilePicker = jest.fn()
   // @ts-ignore
   window.showSaveFilePicker = jest.fn()
 })
@@ -66,11 +66,34 @@ test('showDirectoryPicker', async () => {
 
 test('showFilePicker - error', async () => {
   // @ts-ignore
-  window.showFilePicker.mockImplementation(async () => {
+  window.showOpenFilePicker.mockImplementation(async () => {
     throw new TypeError('x is not a function')
   })
   // @ts-ignore
   await expect(FilePicker.showFilePicker()).rejects.toThrow(new TypeError('x is not a function'))
+})
+
+test('showFilePicker', async () => {
+  // @ts-ignore
+  window.showOpenFilePicker.mockImplementation(async () => {
+    return [
+      {
+        kind: 'file',
+        name: 'test.txt',
+      },
+    ]
+  })
+  // @ts-ignore
+  expect(await FilePicker.showFilePicker()).toEqual([
+    {
+      kind: 'file',
+      name: 'test.txt',
+    },
+  ])
+  // @ts-ignore
+  expect(window.showOpenFilePicker).toHaveBeenCalledTimes(1)
+  // @ts-ignore
+  expect(window.showOpenFilePicker).toHaveBeenCalledWith(undefined)
 })
 
 test('showSaveFilePicker - error', async () => {


### PR DESCRIPTION
Fixes the web file picker bridge to call the native `window.showOpenFilePicker` API for open-file requests.

This lets the renderer worker receive the selected `FileSystemFileHandle` from browsers that support the File System Access API.
