### PR TITLE
fix: preserve focus across viewlet renders

### DIFF
--- a/packages/renderer-process/src/parts/RememberFocus/RememberFocus.ts
+++ b/packages/renderer-process/src/parts/RememberFocus/RememberFocus.ts
@@ -1,3 +1,3 @@
 import * as VirtualDom from '../VirtualDom/VirtualDom.ts'
 
-export const rememberFocus = VirtualDom.rememberFocus2
+export const rememberFocus = VirtualDom.rememberFocus

--- a/packages/renderer-process/test/Viewlet.test.ts
+++ b/packages/renderer-process/test/Viewlet.test.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import { beforeEach, expect, test } from '@jest/globals'
+import { VirtualDomElements } from '@lvce-editor/virtual-dom'
 import * as Layout from '../src/parts/Layout/Layout.ts'
 import * as Viewlet from '../src/parts/Viewlet/Viewlet.ts'
 import * as ViewletState from '../src/parts/ViewletState/ViewletState.ts'
@@ -58,4 +59,63 @@ test('appendViewlet applies pending selector focus after mounting child viewlet'
   Viewlet.appendViewlet('TestParent', 'TestEditor', false)
 
   expect(document.activeElement).toBe(document.querySelector('.EditorInput textarea'))
+})
+
+test('setDom2 preserves focused input state', () => {
+  Object.defineProperty(globalThis, 'CSS', {
+    configurable: true,
+    value: {
+      escape: (value: string) => value,
+    },
+  })
+  const initialDom = [
+    {
+      childCount: 1,
+      className: 'FindWidget',
+      type: VirtualDomElements.Div,
+    },
+    {
+      childCount: 0,
+      className: 'MultilineInputBox before',
+      name: 'search-value',
+      placeholder: 'Find',
+      type: VirtualDomElements.TextArea,
+    },
+  ]
+  const updatedDom = [
+    {
+      childCount: 1,
+      className: 'FindWidget',
+      type: VirtualDomElements.Div,
+    },
+    {
+      childCount: 0,
+      className: 'MultilineInputBox after',
+      name: 'search-value',
+      placeholder: 'Find in file',
+      type: VirtualDomElements.TextArea,
+    },
+  ]
+
+  Viewlet.executeCommands([
+    ['Viewlet.createFunctionalRoot', 'TestFindWidget', 101, true],
+    ['Viewlet.setDom2', 101, initialDom],
+    ['Viewlet.appendToBody', 101],
+  ])
+  const input = document.querySelector<HTMLTextAreaElement>('[name="search-value"]')
+  expect(input).not.toBeNull()
+  input?.focus()
+  input?.setRangeText('content')
+  input?.setSelectionRange(3, 5)
+
+  Viewlet.executeCommands([['Viewlet.setDom2', 101, updatedDom]])
+
+  const updatedInput = document.querySelector<HTMLTextAreaElement>('[name="search-value"]')
+  expect(updatedInput).toBe(input)
+  expect(document.activeElement).toBe(updatedInput)
+  expect(updatedInput?.value).toBe('content')
+  expect(updatedInput?.selectionStart).toBe(3)
+  expect(updatedInput?.selectionEnd).toBe(5)
+  expect(updatedInput?.className).toBe('MultilineInputBox after')
+  expect(updatedInput?.placeholder).toBe('Find in file')
 })


### PR DESCRIPTION
Preserve the active form control, its value, and caret selection when Viewlet.setDom2 updates a functional view. This keeps the Find input focused while match results re-render.