### PR TITLE
fix: avoid duplicate session history items

### DIFF
--- a/packages/renderer-process/src/parts/Location/Location.ts
+++ b/packages/renderer-process/src/parts/Location/Location.ts
@@ -10,18 +10,17 @@ export const getHref = () => {
   return location.href
 }
 
-const matchesPathName = (a: string, b: string) => {
-  return a === b || (a === '/' && b === '') || (a === '' && b === '/')
+const matchesPathName = (currentPathName: string, pathName: string) => {
+  const resolvedPathName = new URL(pathName, getHref()).pathname
+  return currentPathName === resolvedPathName
 }
 
-// TODO should do nothing if it is already at this path
-export const setPathName = (pathName) => {
+export const setPathName = (pathName: string) => {
   const currentPathName = getPathName()
   if (matchesPathName(currentPathName, pathName)) {
     return
   }
-  // @ts-expect-error
-  history.pushState(null, null, pathName)
+  history.pushState(null, '', pathName)
 }
 
 export const hydrate = () => {

--- a/packages/renderer-process/test/Location.test.ts
+++ b/packages/renderer-process/test/Location.test.ts
@@ -27,15 +27,18 @@ test('setPathName', () => {
   const spy = jest.spyOn(history, 'pushState').mockImplementation(() => {})
   Location.setPathName('/test')
   expect(spy).toHaveBeenCalledTimes(1)
-  // @ts-ignore
-  expect(spy).toHaveBeenCalledWith(null, null, '/test')
+  expect(spy).toHaveBeenCalledWith(null, '', '/test')
 })
 
-test.skip('setPathName - should do nothing if we are already at the url', () => {
-  // @ts-ignore
-  delete window.location
-  // @ts-ignore
-  window.location = { pathname: '/test' }
+test('setPathName - should do nothing when the resolved URL is unchanged', () => {
+  history.replaceState(null, '', '/language-features-nvmrc/')
+  const spy = jest.spyOn(history, 'pushState').mockImplementation(() => {})
+  Location.setPathName('')
+  expect(spy).not.toHaveBeenCalled()
+})
+
+test('setPathName - should do nothing if we are already at the url', () => {
+  history.replaceState(null, '', '/test')
   const spy = jest.spyOn(history, 'pushState').mockImplementation(() => {})
   Location.setPathName('/test')
   expect(spy).not.toHaveBeenCalled()


### PR DESCRIPTION
Fix hosted editor startup so an unchanged resolved URL does not create a duplicate session history entry. Add regression coverage for GitHub Pages-style subpaths and ordinary unchanged paths.