### PR TITLE
fix: support current-window URL redirects

### DIFF
--- a/packages/renderer-process/src/parts/Open/Open.ts
+++ b/packages/renderer-process/src/parts/Open/Open.ts
@@ -1,7 +1,11 @@
-export const openUrl = (url: string) => {
-  window.open(url)
-}
-
 export const redirectToUrl = (url: string) => {
   window.location.assign(url)
+}
+
+export const openUrl = (url: string, useRedirect: boolean = false) => {
+  if (useRedirect) {
+    redirectToUrl(url)
+    return
+  }
+  window.open(url)
 }

--- a/packages/renderer-process/test/Open.test.ts
+++ b/packages/renderer-process/test/Open.test.ts
@@ -1,14 +1,38 @@
-/**
- * @jest-environment jsdom
- */
 import { expect, jest, test } from '@jest/globals'
 import * as Open from '../src/parts/Open/Open.ts'
 
-test('openUrl', () => {
-  const spy = jest.spyOn(globalThis, 'open').mockImplementation(() => {
-    return null
+const setWindow = (open: jest.Mock, assign: jest.Mock): void => {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {
+      location: {
+        assign,
+      },
+      open,
+    },
   })
+}
+
+test('openUrl opens a new window by default', () => {
+  const open = jest.fn()
+  const assign = jest.fn()
+  setWindow(open, assign)
+
   Open.openUrl('test://test.txt')
-  expect(spy).toHaveBeenCalledTimes(1)
-  expect(spy).toHaveBeenCalledWith('test://test.txt')
+
+  expect(open).toHaveBeenCalledTimes(1)
+  expect(open).toHaveBeenCalledWith('test://test.txt')
+  expect(assign).not.toHaveBeenCalled()
+})
+
+test('openUrl redirects the current window when requested', () => {
+  const open = jest.fn()
+  const assign = jest.fn()
+  setWindow(open, assign)
+
+  Open.openUrl('test://test.txt', true)
+
+  expect(assign).toHaveBeenCalledTimes(1)
+  expect(assign).toHaveBeenCalledWith('test://test.txt')
+  expect(open).not.toHaveBeenCalled()
 })


### PR DESCRIPTION
Honor the existing URL redirect flag by navigating the current window instead of opening a new tab. Preserve new-window behavior when redirect mode is not requested, with regression coverage for both paths.