### PR TITLE
feature: accept direct test worker rpc

### DIFF
--- a/packages/renderer-process/src/parts/CommandMap/CommandMap.ts
+++ b/packages/renderer-process/src/parts/CommandMap/CommandMap.ts
@@ -22,6 +22,7 @@ import * as Performance from '../Performance/Performance.ts'
 import * as Prompt from '../Prompt/Prompt.ts'
 import * as ScreenCapture from '../ScreenCapture/ScreenCapture.ts'
 import * as TestFramework from '../TestFrameWork/TestFrameWork.ts'
+import * as TestWorkerRpc from '../TestWorkerRpc/TestWorkerRpc.ts'
 import * as Transferrable from '../Transferrable/Transferrable.ts'
 import * as Viewlet from '../Viewlet/Viewlet.ts'
 import * as WebStorage from '../WebStorage/WebStorage.ts'
@@ -94,6 +95,7 @@ export const commandMap = {
   'TestFrameWork.showTestResults': TestFramework.showTestResults,
   'TestFrameWork.transfer': Transferrable.transfer,
   'TestFrameWork.transferToWebView': Transferrable.transferToWebView,
+  'TestWorkerRpc.initialize': TestWorkerRpc.initialize,
   'Viewlet.addKeyBindings': Viewlet.addKeyBindings,
   'Viewlet.appendViewlet': Viewlet.appendViewlet,
   'Viewlet.dispose': Viewlet.dispose,

--- a/packages/renderer-process/src/parts/TestWorkerRpc/TestWorkerRpc.ts
+++ b/packages/renderer-process/src/parts/TestWorkerRpc/TestWorkerRpc.ts
@@ -1,0 +1,26 @@
+import { PlainMessagePortRpcParent, type Rpc } from '@lvce-editor/rpc'
+import * as TestFrameWork from '../TestFrameWork/TestFrameWork.ts'
+
+export const commandMap = {
+  'TestFrameWork.checkConditionError': TestFrameWork.checkConditionError,
+  'TestFrameWork.checkMultiElementCondition': TestFrameWork.checkMultiElementCondition,
+  'TestFrameWork.checkSingleElementCondition': TestFrameWork.checkSingleElementCondition,
+  'TestFrameWork.performAction': TestFrameWork.performAction,
+  'TestFrameWork.performAction2': TestFrameWork.performAction2,
+  'TestFrameWork.performKeyBoardAction': TestFrameWork.performKeyboardAction,
+  'TestFrameWork.showOverlay': TestFrameWork.showOverlay,
+  'TestFrameWork.showTestResults': TestFrameWork.showTestResults,
+}
+
+export const state: { rpc: Rpc | undefined } = {
+  rpc: undefined,
+}
+
+export const initialize = async (port: MessagePort): Promise<void> => {
+  const rpc = await PlainMessagePortRpcParent.create({
+    commandMap,
+    messagePort: port,
+  })
+  await state.rpc?.dispose()
+  state.rpc = rpc
+}

--- a/packages/renderer-process/test/TestWorkerRpc.test.ts
+++ b/packages/renderer-process/test/TestWorkerRpc.test.ts
@@ -1,0 +1,53 @@
+import type { Rpc } from '@lvce-editor/rpc'
+import { afterEach, expect, jest, test } from '@jest/globals'
+import * as TestFrameWork from '../src/parts/TestFrameWork/TestFrameWork.ts'
+
+const dispose = jest.fn(async (): Promise<void> => undefined)
+const rpc = {
+  dispose,
+} as unknown as Rpc
+const create = jest.fn<(_options: any) => Promise<Rpc>>(async () => rpc)
+
+jest.unstable_mockModule('@lvce-editor/rpc', () => ({
+  PlainMessagePortRpcParent: {
+    create,
+  },
+}))
+
+const TestWorkerRpc = await import('../src/parts/TestWorkerRpc/TestWorkerRpc.ts')
+
+afterEach(() => {
+  TestWorkerRpc.state.rpc = undefined
+  create.mockClear()
+  dispose.mockClear()
+})
+
+test('initialize creates a direct rpc with renderer-local test framework commands', async () => {
+  const port = {} as MessagePort
+
+  await TestWorkerRpc.initialize(port)
+
+  expect(create).toHaveBeenCalledTimes(1)
+  expect(create).toHaveBeenCalledWith({
+    commandMap: {
+      'TestFrameWork.checkConditionError': TestFrameWork.checkConditionError,
+      'TestFrameWork.checkMultiElementCondition': TestFrameWork.checkMultiElementCondition,
+      'TestFrameWork.checkSingleElementCondition': TestFrameWork.checkSingleElementCondition,
+      'TestFrameWork.performAction': TestFrameWork.performAction,
+      'TestFrameWork.performAction2': TestFrameWork.performAction2,
+      'TestFrameWork.performKeyBoardAction': TestFrameWork.performKeyboardAction,
+      'TestFrameWork.showOverlay': TestFrameWork.showOverlay,
+      'TestFrameWork.showTestResults': TestFrameWork.showTestResults,
+    },
+    messagePort: port,
+  })
+  expect(TestWorkerRpc.state.rpc).toBe(rpc)
+})
+
+test('initialize disposes the previous direct rpc', async () => {
+  TestWorkerRpc.state.rpc = rpc
+
+  await TestWorkerRpc.initialize({} as MessagePort)
+
+  expect(dispose).toHaveBeenCalledTimes(1)
+})


### PR DESCRIPTION
Accepts a dedicated test-worker MessagePort and serves renderer-local test framework checks, actions, keyboard input, overlays, and results directly from renderer-process.