### PR TITLE
feature: accept compact test locators

### DIFF
--- a/packages/renderer-process/src/parts/TestFrameWork/ConditionValues.ts
+++ b/packages/renderer-process/src/parts/TestFrameWork/ConditionValues.ts
@@ -1,7 +1,9 @@
+import * as GetParsedSelector from './GetParsedSelector.ts'
 import * as QuerySelector from './QuerySelector.ts'
 
 const getElementText = (locator) => {
-  const element = QuerySelector.querySelectorOne(locator._parsed)
+  const parsedSelector = GetParsedSelector.getParsedSelector(locator)
+  const element = QuerySelector.querySelectorOne(parsedSelector)
   if (!element) {
     return {
       actual: '',
@@ -23,7 +25,8 @@ export const toContainText = (locator) => {
 }
 
 export const toHaveAttribute = (locator, { key, value }) => {
-  const element = QuerySelector.querySelectorOne(locator._parsed)
+  const parsedSelector = GetParsedSelector.getParsedSelector(locator)
+  const element = QuerySelector.querySelectorOne(parsedSelector)
   if (!element) {
     return {
       actual: '',
@@ -38,7 +41,8 @@ export const toHaveAttribute = (locator, { key, value }) => {
 }
 
 export const toHaveCount = (locator) => {
-  const elements = QuerySelector.querySelector(locator._parsed)
+  const parsedSelector = GetParsedSelector.getParsedSelector(locator)
+  const elements = QuerySelector.querySelector(parsedSelector)
   const actualCount = elements.length
   return {
     actual: actualCount,
@@ -67,7 +71,8 @@ export const toBeFocused = (locator) => {
 }
 
 export const toHaveClass = (locator, { className }) => {
-  const [element] = QuerySelector.querySelector(locator._parsed)
+  const parsedSelector = GetParsedSelector.getParsedSelector(locator)
+  const [element] = QuerySelector.querySelector(parsedSelector)
   if (!element) {
     return {
       actual: '',
@@ -81,7 +86,8 @@ export const toHaveClass = (locator, { className }) => {
 }
 
 export const toHaveId = (locator) => {
-  const [element] = QuerySelector.querySelector(locator._parsed)
+  const parsedSelector = GetParsedSelector.getParsedSelector(locator)
+  const [element] = QuerySelector.querySelector(parsedSelector)
   if (!element) {
     return {
       actual: '',
@@ -95,7 +101,8 @@ export const toHaveId = (locator) => {
 }
 
 export const toHaveCss = (locator, { key }) => {
-  const [element] = QuerySelector.querySelector(locator._parsed)
+  const parsedSelector = GetParsedSelector.getParsedSelector(locator)
+  const [element] = QuerySelector.querySelector(parsedSelector)
   if (!element) {
     return {
       actual: '',
@@ -111,7 +118,8 @@ export const toHaveCss = (locator, { key }) => {
 }
 
 export const toHaveJSProperty = (locator, { key }) => {
-  const [element] = QuerySelector.querySelector(locator._parsed)
+  const parsedSelector = GetParsedSelector.getParsedSelector(locator)
+  const [element] = QuerySelector.querySelector(parsedSelector)
   if (!element) {
     return {
       actual: '',

--- a/packages/renderer-process/src/parts/TestFrameWork/GetParsedSelector.ts
+++ b/packages/renderer-process/src/parts/TestFrameWork/GetParsedSelector.ts
@@ -1,0 +1,12 @@
+import type { ParsedCssSelector } from './ParsedCssSelector.ts'
+
+interface LegacyLocator {
+  readonly _parsed: ParsedCssSelector
+}
+
+export const getParsedSelector = (locator: ParsedCssSelector | LegacyLocator): ParsedCssSelector => {
+  if (Array.isArray(locator)) {
+    return locator
+  }
+  return (locator as LegacyLocator)._parsed
+}

--- a/packages/renderer-process/src/parts/TestFrameWork/TestFrameWork.ts
+++ b/packages/renderer-process/src/parts/TestFrameWork/TestFrameWork.ts
@@ -4,6 +4,7 @@ import * as SetBounds from '../SetBounds/SetBounds.ts'
 import type { ConditionResult } from './ConditionResult.ts'
 import * as ConditionValues from './ConditionValues.ts'
 import * as ElementActions from './ElementActions.ts'
+import * as GetParsedSelector from './GetParsedSelector.ts'
 import * as KeyboardActions from './KeyBoardActions.ts'
 import * as RendererWorker from '../RendererWorker/RendererWorker.ts'
 import * as MultiElementConditions from './MultiElementConditions.ts'
@@ -89,7 +90,8 @@ export const performKeyboardAction = (fnName, options) => {
 
 export const checkSingleElementCondition = async (locator, fnName, options): Promise<ConditionResult> => {
   const fn = SingleElementConditions[fnName]
-  const element = QuerySelector.querySelectorOne(locator._parsed)
+  const parsedSelector = GetParsedSelector.getParsedSelector(locator)
+  const element = QuerySelector.querySelectorOne(parsedSelector)
   if (element) {
     const successful = fn(element, options)
     if (successful) {
@@ -103,7 +105,8 @@ export const checkSingleElementCondition = async (locator, fnName, options): Pro
 
 export const checkMultiElementCondition = async (locator, fnName, options): Promise<ConditionResult> => {
   const fn = MultiElementConditions[fnName]
-  const elements = QuerySelector.querySelector(locator._parsed)
+  const parsedSelector = GetParsedSelector.getParsedSelector(locator)
+  const elements = QuerySelector.querySelector(parsedSelector)
   const successful = fn(elements, options)
   if (successful) {
     return {

--- a/packages/renderer-process/test/TestFrameWork.test.ts
+++ b/packages/renderer-process/test/TestFrameWork.test.ts
@@ -40,3 +40,84 @@ test('type dispatches input event', () => {
   expect(events).toHaveLength(1)
   expect(events[0]).toBeInstanceOf(InputEvent)
 })
+
+test('checkSingleElementCondition accepts a compact parsed selector', async () => {
+  document.body.innerHTML = '<main><button>Save</button><button>Save</button></main>'
+  const parsedSelector = [
+    {
+      selector: 'main',
+      type: 'css' as const,
+    },
+    {
+      selector: 'button',
+      type: 'css' as const,
+    },
+    {
+      text: 'Save',
+      type: 'has-text' as const,
+    },
+    {
+      index: 0,
+      type: 'nth' as const,
+    },
+  ]
+
+  await expect(TestFrameWork.checkSingleElementCondition(parsedSelector, 'toHaveText', { text: 'Save' })).resolves.toEqual({ error: false })
+})
+
+test('checkMultiElementCondition accepts a compact parsed selector', async () => {
+  document.body.innerHTML = '<main><div class="item"></div><div class="item"></div></main>'
+  const parsedSelector = [
+    {
+      selector: 'main',
+      type: 'css' as const,
+    },
+    {
+      selector: '.item',
+      type: 'css' as const,
+    },
+  ]
+
+  await expect(TestFrameWork.checkMultiElementCondition(parsedSelector, 'toHaveCount', { count: 2 })).resolves.toEqual({ error: false })
+})
+
+test('condition checks continue to accept a legacy locator', async () => {
+  document.body.innerHTML = '<button class="target">Save</button>'
+  const parsedSelector = [
+    {
+      selector: '.target',
+      type: 'css' as const,
+    },
+  ]
+  const locator = {
+    _parsed: parsedSelector,
+    _selector: '.target',
+  }
+
+  await expect(TestFrameWork.checkSingleElementCondition(locator, 'toBeVisible', {})).resolves.toEqual({ error: false })
+  await expect(TestFrameWork.checkMultiElementCondition(locator, 'toHaveCount', { count: 1 })).resolves.toEqual({ error: false })
+})
+
+test('condition error values accept compact and legacy locators', async () => {
+  document.body.innerHTML = '<button class="target">Save</button>'
+  const parsedSelector = [
+    {
+      selector: '.target',
+      type: 'css' as const,
+    },
+  ]
+
+  expect(await TestFrameWork.checkConditionError('toHaveText', parsedSelector)).toEqual({
+    actual: 'Save',
+    wasFound: true,
+  })
+  expect(
+    await TestFrameWork.checkConditionError('toHaveText', {
+      _parsed: parsedSelector,
+      _selector: '.target',
+    }),
+  ).toEqual({
+    actual: 'Save',
+    wasFound: true,
+  })
+})


### PR DESCRIPTION
Adds the backward-compatible consumer for compact test locator payloads. Test conditions and failure-value queries now normalize either the existing locator object or a parsed-selector array before querying the DOM.\n\nCoverage includes single/multi conditions, chained CSS selectors, has-text/nth, failure-value lookup, and legacy compatibility.\n\nTests: focused renderer-process Jest suites (13 passed); type-check; lint.