### PR TITLE
feature: lazily load xterm chunk

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -21,7 +21,7 @@
       "project": ["src/**/*.ts"]
     },
     "packages/renderer-process": {
-      "entry": ["src/rendererProcessMain.ts", "test/**/*.test.ts"],
+      "entry": ["src/rendererProcessMain.ts", "src/xterm.ts", "test/**/*.test.ts"],
       "project": ["src/**/*.ts", "test/**/*.ts"],
       "ignoreFiles": ["src/parts/**"],
       "ignoreIssues": {

--- a/packages/build/src/build.js
+++ b/packages/build/src/build.js
@@ -57,6 +57,17 @@ await bundleJs({
   from: 'packages/renderer-process/src/rendererProcessMain.ts',
   platform: 'webworker',
   outFile: '.tmp/dist/dist/rendererProcessMain.js',
+  external: ['@xterm/xterm'],
+  paths: {
+    '@xterm/xterm': './xterm.js',
+  },
+})
+
+await bundleJs({
+  cwd: root,
+  from: 'packages/renderer-process/src/xterm.ts',
+  platform: 'webworker',
+  outFile: '.tmp/dist/dist/xterm.js',
   external: [],
 })
 

--- a/packages/build/src/bundleJs.js
+++ b/packages/build/src/bundleJs.js
@@ -16,7 +16,7 @@ const getExternal = (babelExternal, initialExternal) => {
 /**
  *
  * @param {{from:string,cwd:string, exclude?:string[], platform:'node'|'webworker'|'web'|'node/cjs', minify?:boolean, codeSplitting?:boolean, babelExternal?:boolean, typescript?:boolean, outFile:string
- * allowCyclicDependencies?:boolean, external?:string[] }} param0
+ * allowCyclicDependencies?:boolean, external?:string[], paths?:Record<string, string> }} param0
  */
 export const bundleJs = async ({
   cwd,
@@ -24,6 +24,7 @@ export const bundleJs = async ({
   codeSplitting = false,
   babelExternal = false,
   external = [],
+  paths = {},
   typescript = from.endsWith('.ts'),
   outFile,
 }) => {
@@ -90,7 +91,7 @@ export const bundleJs = async ({
      * @type {import('rollup').OutputOptions}
      */
     const outputOptions = {
-      paths: {},
+      paths,
       sourcemap: false,
       format: outputFormat,
       extend: false,

--- a/packages/renderer-process/src/parts/ViewletTerminal2/ViewletTerminal2.ts
+++ b/packages/renderer-process/src/parts/ViewletTerminal2/ViewletTerminal2.ts
@@ -1,11 +1,11 @@
-import { Terminal } from '@xterm/xterm'
 import * as Assert from '../Assert/Assert.ts'
 import * as ForwardCommand from '../ForwardCommand/ForwardCommand.ts'
 
 const defaultColumns = 80
 const defaultRows = 24
 
-const createTerminal = () => {
+const createTerminal = async () => {
+  const { Terminal } = await import('@xterm/xterm')
   return new Terminal({
     cols: defaultColumns,
     convertEol: true,
@@ -24,11 +24,11 @@ export const create = () => {
   }
 }
 
-export const setTerminal = (state, uid) => {
+export const setTerminal = async (state, uid) => {
   if (state.terminal) {
     return
   }
-  const terminal = createTerminal()
+  const terminal = await createTerminal()
   const inputDisposable = terminal.onData((data) => {
     ForwardCommand.handleInput(uid, data)
   })

--- a/packages/renderer-process/src/xterm.ts
+++ b/packages/renderer-process/src/xterm.ts
@@ -1,0 +1,1 @@
+export { Terminal } from '@xterm/xterm'

--- a/packages/renderer-process/test/ViewletTerminal2.test.ts
+++ b/packages/renderer-process/test/ViewletTerminal2.test.ts
@@ -71,9 +71,9 @@ test('create', () => {
   expect(state.terminal).toBeUndefined()
 })
 
-test('setTerminal', () => {
+test('setTerminal', async () => {
   const state = ViewletTerminal2.create()
-  ViewletTerminal2.setTerminal(state, 1)
+  await ViewletTerminal2.setTerminal(state, 1)
   const terminal = terminalInstances.at(-1)!
 
   expect(terminal.opened).toBe(true)
@@ -84,18 +84,18 @@ test('setTerminal', () => {
   expect(resize).toHaveBeenCalledWith(1, { columns: 120, rows: 40 })
 })
 
-test('write', () => {
+test('write', async () => {
   const state = ViewletTerminal2.create()
-  ViewletTerminal2.setTerminal(state, 2)
+  await ViewletTerminal2.setTerminal(state, 2)
   const terminal = terminalInstances.at(-1)!
   const data = new Uint8Array([97, 98, 99])
   ViewletTerminal2.write(state, data)
   expect(terminal.written).toEqual([data])
 })
 
-test('attachEvents focuses terminal on mousedown', () => {
+test('attachEvents focuses terminal on mousedown', async () => {
   const state = ViewletTerminal2.create()
-  ViewletTerminal2.setTerminal(state, 3)
+  await ViewletTerminal2.setTerminal(state, 3)
   ViewletTerminal2.attachEvents(state)
   const terminal = terminalInstances.at(-1)!
 
@@ -104,9 +104,9 @@ test('attachEvents focuses terminal on mousedown', () => {
   expect(terminal.focused).toBe(true)
 })
 
-test('dispose', () => {
+test('dispose', async () => {
   const state = ViewletTerminal2.create()
-  ViewletTerminal2.setTerminal(state, 4)
+  await ViewletTerminal2.setTerminal(state, 4)
   const terminal = terminalInstances.at(-1)!
   ViewletTerminal2.dispose(state)
   expect(terminal.disposed).toBe(true)


### PR DESCRIPTION
Lazily imports xterm when the xterm terminal is initialized.

Builds xterm as a sibling chunk so renderer startup no longer evaluates or transfers the terminal library.