### PR TITLE
fix: route activity bar clicks by item index

### DIFF
--- a/packages/renderer-process/src/parts/ViewletActivityBar/ViewletActivityBarEvents.ts
+++ b/packages/renderer-process/src/parts/ViewletActivityBar/ViewletActivityBarEvents.ts
@@ -14,7 +14,7 @@ export const handleMouseDown = (event) => {
   Event.preventDefault(event)
   Event.stopPropagation(event)
   const index = GetNodeIndex.getNodeIndex($Item)
-  return ['handleClick', button, index, clientX, clientY]
+  return ['handleClickIndex', button, index, clientX, clientY]
 }
 
 export const handleBlur = () => {

--- a/packages/renderer-process/test/ViewletNavigationEvents.test.ts
+++ b/packages/renderer-process/test/ViewletNavigationEvents.test.ts
@@ -60,28 +60,28 @@ const createActivityBar = (): { activityBar: HTMLElement; firstItem: HTMLButtonE
 test('activity bar handles a mouse down on the item', () => {
   const { firstItem } = createActivityBar()
 
-  expect(dispatchActivityBarMouseDown(firstItem)).toEqual(['handleClick', 0, 0, 12, 34])
+  expect(dispatchActivityBarMouseDown(firstItem)).toEqual(['handleClickIndex', 0, 0, 12, 34])
 })
 
 test('activity bar handles a mouse down on the item icon', () => {
   const { secondItem } = createActivityBar()
   const icon = secondItem.querySelector('.ActivityBarItemIcon') as HTMLElement
 
-  expect(dispatchActivityBarMouseDown(icon)).toEqual(['handleClick', 0, 1, 12, 34])
+  expect(dispatchActivityBarMouseDown(icon)).toEqual(['handleClickIndex', 0, 1, 12, 34])
 })
 
 test('activity bar handles a mouse down on a nested mask icon', () => {
   const { secondItem } = createActivityBar()
   const maskIcon = secondItem.querySelector('.MaskIcon') as HTMLElement
 
-  expect(dispatchActivityBarMouseDown(maskIcon)).toEqual(['handleClick', 0, 1, 12, 34])
+  expect(dispatchActivityBarMouseDown(maskIcon)).toEqual(['handleClickIndex', 0, 1, 12, 34])
 })
 
 test('activity bar handles a mouse down on a deeply nested icon decoration', () => {
   const { secondItem } = createActivityBar()
   const decoration = secondItem.querySelector('.MaskIconDecoration') as HTMLElement
 
-  expect(dispatchActivityBarMouseDown(decoration)).toEqual(['handleClick', 0, 1, 12, 34])
+  expect(dispatchActivityBarMouseDown(decoration)).toEqual(['handleClickIndex', 0, 1, 12, 34])
 })
 
 const createSourceControl = (): { firstButton: HTMLButtonElement; root: HTMLElement; secondButton: HTMLButtonElement } => {


### PR DESCRIPTION
## Summary
- send Activity Bar DOM clicks to the index-based worker command
- preserve the resolved item index for direct and nested icon targets
- update regression coverage for direct, icon, mask, and deeply nested click targets

## Tests
- focused renderer navigation events: 8 passed
- npm run lint
- npm run type-check