### PR TITLE
fix: dispose module workers by id

### DIFF
--- a/packages/renderer-process/src/parts/CommandMap/CommandMap.ts
+++ b/packages/renderer-process/src/parts/CommandMap/CommandMap.ts
@@ -57,6 +57,7 @@ export const commandMap = {
   'HandleMessagePort.handleMessagePort': HandleMessagePort.handleMessagePort,
   'InitData.getInitData': InitData.getInitData,
   'IpcParent.create': IpcParent.create,
+  'IpcParent.dispose': IpcParent.dispose,
   'KeyBindings.setIdentifiers': KeyBindings.setIdentifiers,
   'Layout.getBounds': Layout.getBounds,
   'Location.getHref': Location.getHref,

--- a/packages/renderer-process/src/parts/IpcParent/IpcParent.ts
+++ b/packages/renderer-process/src/parts/IpcParent/IpcParent.ts
@@ -1,5 +1,6 @@
 import * as IpcParentModule from '../IpcParentModule/IpcParentModule.ts'
 import * as IpcStates from '../IpcStates/IpcStates.ts'
+import * as ModuleWorkerState from '../ModuleWorkerState/ModuleWorkerState.ts'
 import * as RendererWorker from '../RendererWorker/RendererWorker.ts'
 import * as ShouldLaunchMultipleWorkers from '../ShouldLaunchMultipleWorkers/ShouldLaunchMultipleWorkers.ts'
 
@@ -18,4 +19,9 @@ export const create = async ({ method, ...options }) => {
   const module = await IpcParentModule.getModule(method)
   // @ts-ignore
   return module.create(options)
+}
+
+export const dispose = (id: number): void => {
+  const worker = ModuleWorkerState.remove(id)
+  worker?.terminate()
 }

--- a/packages/renderer-process/src/parts/IpcParentWithModuleWorkerWithMessagePort/IpcParentWithModuleWorkerWithMessagePort.ts
+++ b/packages/renderer-process/src/parts/IpcParentWithModuleWorkerWithMessagePort/IpcParentWithModuleWorkerWithMessagePort.ts
@@ -1,12 +1,27 @@
-import { ModuleWorkerWithMessagePortRpcParent } from '@lvce-editor/rpc'
+import { ModuleWorkerWithMessagePortRpcParent, type Rpc } from '@lvce-editor/rpc'
+import * as ModuleWorkerState from '../ModuleWorkerState/ModuleWorkerState.ts'
 
-// TODO add test
-export const create = async ({ name, port, url }) => {
-  await ModuleWorkerWithMessagePortRpcParent.create({
+interface RpcWithWorker extends Rpc {
+  readonly ipc?: {
+    readonly _rawIpc?: Worker
+  }
+}
+
+type CreateRpc = typeof ModuleWorkerWithMessagePortRpcParent.create
+
+export const create = async (
+  { id, name, port, url }: { readonly id?: number; readonly name?: string; readonly port: MessagePort; readonly url: string },
+  createRpc: CreateRpc = ModuleWorkerWithMessagePortRpcParent.create,
+) => {
+  const rpc = (await createRpc({
     commandMap: {},
     name,
     port,
     url,
-  })
+  })) as RpcWithWorker
+  const worker = rpc.ipc?._rawIpc
+  if (typeof id === 'number' && worker) {
+    ModuleWorkerState.set(id, worker)
+  }
   return undefined
 }

--- a/packages/renderer-process/src/parts/IpcParentWithModuleWorkerWithMessagePort/IpcParentWithModuleWorkerWithMessagePort.ts
+++ b/packages/renderer-process/src/parts/IpcParentWithModuleWorkerWithMessagePort/IpcParentWithModuleWorkerWithMessagePort.ts
@@ -10,7 +10,13 @@ interface RpcWithWorker extends Rpc {
 type CreateRpc = typeof ModuleWorkerWithMessagePortRpcParent.create
 
 export const create = async (
-  { id, name, port, url }: { readonly id?: number; readonly name?: string; readonly port: MessagePort; readonly url: string },
+  {
+    id,
+    name,
+    port,
+    raw,
+    url,
+  }: { readonly id?: number; readonly name?: string; readonly port: MessagePort; readonly raw?: boolean; readonly url: string },
   createRpc: CreateRpc = ModuleWorkerWithMessagePortRpcParent.create,
 ) => {
   const rpc = (await createRpc({
@@ -20,7 +26,7 @@ export const create = async (
     url,
   })) as RpcWithWorker
   const worker = rpc.ipc?._rawIpc
-  if (typeof id === 'number' && worker) {
+  if (typeof id === 'number' && raw && worker) {
     ModuleWorkerState.set(id, worker)
   }
   return undefined

--- a/packages/renderer-process/src/parts/ModuleWorkerState/ModuleWorkerState.ts
+++ b/packages/renderer-process/src/parts/ModuleWorkerState/ModuleWorkerState.ts
@@ -1,0 +1,21 @@
+interface DisposableWorker {
+  terminate(): void
+}
+
+const workers: Record<number, DisposableWorker | undefined> = Object.create(null)
+
+export const set = (id: number, worker: DisposableWorker): void => {
+  workers[id] = worker
+}
+
+export const remove = (id: number): DisposableWorker | undefined => {
+  const worker = workers[id]
+  delete workers[id]
+  return worker
+}
+
+export const clear = (): void => {
+  for (const id of Object.keys(workers)) {
+    delete workers[Number(id)]
+  }
+}

--- a/packages/renderer-process/test/DisposeModuleWorker.test.ts
+++ b/packages/renderer-process/test/DisposeModuleWorker.test.ts
@@ -26,6 +26,7 @@ test('dispose terminates a registered module worker', async () => {
     id: 42,
     name: 'Extension API: sample.extension',
     port: {} as MessagePort,
+    raw: true,
     url: 'https://example.com/extensionHostSubWorker.js',
   }, mockCreate)
 
@@ -39,6 +40,7 @@ test('dispose removes the registered worker', async () => {
     id: 42,
     name: 'Extension API: sample.extension',
     port: {} as MessagePort,
+    raw: true,
     url: 'https://example.com/extensionHostSubWorker.js',
   }, mockCreate)
 
@@ -52,8 +54,25 @@ test('create without an id does not register the worker', async () => {
   await IpcParentWithModuleWorkerWithMessagePort.create({
     name: 'Extension API',
     port: {} as MessagePort,
+    raw: true,
     url: 'https://example.com/extensionHostSubWorker.js',
   }, mockCreate)
+
+  IpcParent.dispose(42)
+
+  expect(mockTerminate).not.toHaveBeenCalled()
+})
+
+test('create without raw mode does not register the worker', async () => {
+  await IpcParentWithModuleWorkerWithMessagePort.create(
+    {
+      id: 42,
+      name: 'Editor Worker',
+      port: {} as MessagePort,
+      url: 'https://example.com/editorWorker.js',
+    },
+    mockCreate,
+  )
 
   IpcParent.dispose(42)
 

--- a/packages/renderer-process/test/DisposeModuleWorker.test.ts
+++ b/packages/renderer-process/test/DisposeModuleWorker.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const mockCreate = jest.fn<(...args: any[]) => Promise<any>>()
+const mockTerminate = jest.fn()
+
+const IpcParent = await import('../src/parts/IpcParent/IpcParent.ts')
+const IpcParentWithModuleWorkerWithMessagePort = await import(
+  '../src/parts/IpcParentWithModuleWorkerWithMessagePort/IpcParentWithModuleWorkerWithMessagePort.ts'
+)
+const ModuleWorkerState = await import('../src/parts/ModuleWorkerState/ModuleWorkerState.ts')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+  ModuleWorkerState.clear()
+  mockCreate.mockResolvedValue({
+    ipc: {
+      _rawIpc: {
+        terminate: mockTerminate,
+      },
+    },
+  })
+})
+
+test('dispose terminates a registered module worker', async () => {
+  await IpcParentWithModuleWorkerWithMessagePort.create({
+    id: 42,
+    name: 'Extension API: sample.extension',
+    port: {} as MessagePort,
+    url: 'https://example.com/extensionHostSubWorker.js',
+  }, mockCreate)
+
+  IpcParent.dispose(42)
+
+  expect(mockTerminate).toHaveBeenCalledTimes(1)
+})
+
+test('dispose removes the registered worker', async () => {
+  await IpcParentWithModuleWorkerWithMessagePort.create({
+    id: 42,
+    name: 'Extension API: sample.extension',
+    port: {} as MessagePort,
+    url: 'https://example.com/extensionHostSubWorker.js',
+  }, mockCreate)
+
+  IpcParent.dispose(42)
+  IpcParent.dispose(42)
+
+  expect(mockTerminate).toHaveBeenCalledTimes(1)
+})
+
+test('create without an id does not register the worker', async () => {
+  await IpcParentWithModuleWorkerWithMessagePort.create({
+    name: 'Extension API',
+    port: {} as MessagePort,
+    url: 'https://example.com/extensionHostSubWorker.js',
+  }, mockCreate)
+
+  IpcParent.dispose(42)
+
+  expect(mockTerminate).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
## Summary
- retain module worker handles by their renderer IPC id
- add an `IpcParent.dispose` command that terminates and removes a worker
- cover termination, idempotency, and untracked launches

## Test Plan
- `npx tsc -b --force`
- `npm run lint`
- `DisposeModuleWorker.test.ts` (3 tests)