### PR TITLE
feature: trace renderer worker commands

### DIFF
--- a/packages/renderer-process/src/parts/Main/Main.ts
+++ b/packages/renderer-process/src/parts/Main/Main.ts
@@ -3,6 +3,7 @@ import { commandMapRef } from '../CommandMapRef/CommandMapRef.ts'
 import * as ErrorHandling from '../ErrorHandling/ErrorHandling.ts'
 import * as LaunchWorkers from '../LaunchWorkers/LaunchWorkers.ts'
 import * as RendererWorker from '../RendererWorker/RendererWorker.ts'
+import * as RendererWorkerTrace from '../RendererWorkerTrace/RendererWorkerTrace.ts'
 import * as Result from '../Result/Result.ts'
 import * as ViewletColorPicker from '../ViewletColorPicker/ViewletColorPicker.ts'
 import * as ViewletEditorCodeGenerator from '../ViewletEditorCodeGenerator/ViewletEditorCodeGenerator.ts'
@@ -19,6 +20,7 @@ import * as VirtualDom from '../VirtualDom/VirtualDom.ts'
 import * as WindowListeners from '../WindowListeners/WindowListeners.ts'
 
 export const main = async () => {
+  RendererWorkerTrace.initialize(location.search)
   Object.assign(commandMapRef, commandMap)
   WindowListeners.enable(window)
   ViewletState.state.modules[ViewletModuleId.ColorPicker] = ViewletColorPicker

--- a/packages/renderer-process/src/parts/RendererWorker/RendererWorker.ts
+++ b/packages/renderer-process/src/parts/RendererWorker/RendererWorker.ts
@@ -1,5 +1,6 @@
 import type { Rpc } from '@lvce-editor/rpc'
 import * as LaunchRendererWorker from '../LaunchRendererWorker/LaunchRendererWorker.ts'
+import * as RendererWorkerTrace from '../RendererWorkerTrace/RendererWorkerTrace.ts'
 import * as Result from '../Result/Result.ts'
 
 export const state: { rpc: Rpc | undefined } = {
@@ -13,6 +14,7 @@ export const hydrate = async () => {
     return result
   }
   state.rpc = result.value
+  RendererWorkerTrace.listen(result.value)
   return Result.success(undefined)
 }
 
@@ -24,21 +26,27 @@ export const dispose = () => {
 }
 
 export const send = (method, ...params) => {
+  RendererWorkerTrace.record('sent', method, params)
   // @ts-ignore
   state.rpc.send(method, ...params)
 }
 
 export const invoke = (method, ...params) => {
+  RendererWorkerTrace.record('sent', method, params)
   // @ts-ignore
   return state.rpc.invoke(method, ...params)
 }
 
 export const sendAndTransfer = (message) => {
+  if (Array.isArray(message) && typeof message[0] === 'string') {
+    RendererWorkerTrace.record('sent', message[0], message.slice(1))
+  }
   // @ts-expect-error
   state.rpc.sendAndTransfer(message)
 }
 
 export const invokeAndTransfer = (method, ...params) => {
+  RendererWorkerTrace.record('sent', method, params)
   // @ts-ignore
   return state.rpc.invokeAndTransfer(method, ...params)
 }

--- a/packages/renderer-process/src/parts/RendererWorkerTrace/RendererWorkerTrace.ts
+++ b/packages/renderer-process/src/parts/RendererWorkerTrace/RendererWorkerTrace.ts
@@ -1,0 +1,132 @@
+import type { Rpc } from '@lvce-editor/rpc'
+
+type Direction = 'received' | 'sent'
+
+interface TraceEntry {
+  readonly direction: Direction
+  readonly method: string
+  readonly params: readonly unknown[]
+  readonly timestamp: number
+}
+
+interface TraceableIpc extends EventTarget {
+  readonly getData: (event: MessageEvent) => unknown
+}
+
+interface TraceableRpc extends Rpc {
+  readonly ipc?: TraceableIpc
+}
+
+const selector = 'script.RendererWorkerTrace'
+
+const state: {
+  enabled: boolean
+  entries: TraceEntry[]
+} = {
+  enabled: false,
+  entries: [],
+}
+
+const serialize = (value: readonly unknown[]): readonly unknown[] => {
+  const seen = new WeakSet<object>()
+  const text = JSON.stringify(value, (_key, currentValue: unknown) => {
+    if (typeof currentValue === 'bigint') {
+      return `${currentValue}n`
+    }
+    if (typeof currentValue !== 'object' || currentValue === null) {
+      return currentValue
+    }
+    if (seen.has(currentValue)) {
+      return '[Circular]'
+    }
+    seen.add(currentValue)
+    if (currentValue instanceof ArrayBuffer) {
+      return {
+        byteLength: currentValue.byteLength,
+        type: 'ArrayBuffer',
+      }
+    }
+    if (ArrayBuffer.isView(currentValue)) {
+      return {
+        byteLength: currentValue.byteLength,
+        type: currentValue.constructor.name,
+      }
+    }
+    if (currentValue instanceof Error) {
+      return {
+        message: currentValue.message,
+        name: currentValue.name,
+        stack: currentValue.stack,
+      }
+    }
+    if (currentValue.constructor?.name === 'MessagePort') {
+      return {
+        type: 'MessagePort',
+      }
+    }
+    return currentValue
+  })
+  return JSON.parse(text)
+}
+
+const isCommand = (value: unknown): value is { method: string; params?: readonly unknown[] } => {
+  return typeof value === 'object' && value !== null && 'method' in value && typeof value.method === 'string'
+}
+
+export const initialize = (search: string): void => {
+  const searchParams = new URLSearchParams(search)
+  state.enabled = searchParams.has('traceRendererWorker')
+  state.entries = []
+}
+
+export const record = (direction: Direction, method: string, params: readonly unknown[]): void => {
+  if (!state.enabled) {
+    return
+  }
+  state.entries.push({
+    direction,
+    method,
+    params: serialize(params),
+    timestamp: performance.now(),
+  })
+}
+
+export const listen = (rpc: Rpc): void => {
+  if (!state.enabled) {
+    return
+  }
+  const ipc = (rpc as TraceableRpc).ipc
+  if (!ipc) {
+    return
+  }
+  ipc.addEventListener('message', (event) => {
+    const message = ipc.getData(event as MessageEvent)
+    if (isCommand(message)) {
+      record('received', message.method, message.params || [])
+    }
+  })
+}
+
+export const exportToDom = (): void => {
+  if (!state.enabled) {
+    return
+  }
+  const existing = document.querySelector<HTMLScriptElement>(selector)
+  const script = existing || document.createElement('script')
+  script.className = 'RendererWorkerTrace'
+  script.type = 'application/json'
+  script.textContent = JSON.stringify({
+    entries: state.entries,
+    version: 1,
+  })
+  if (!existing) {
+    document.body.append(script)
+  }
+}
+
+export const scheduleExport = (): void => {
+  if (!state.enabled) {
+    return
+  }
+  queueMicrotask(exportToDom)
+}

--- a/packages/renderer-process/src/parts/TestFrameWork/TestFrameWork.ts
+++ b/packages/renderer-process/src/parts/TestFrameWork/TestFrameWork.ts
@@ -9,6 +9,7 @@ import * as KeyboardActions from './KeyBoardActions.ts'
 import * as RendererWorker from '../RendererWorker/RendererWorker.ts'
 import * as MultiElementConditions from './MultiElementConditions.ts'
 import * as QuerySelector from './QuerySelector.ts'
+import * as RendererWorkerTrace from '../RendererWorkerTrace/RendererWorkerTrace.ts'
 import * as SingleElementConditions from './SingleElementConditions.ts'
 
 const create$Overlay = () => {
@@ -26,8 +27,6 @@ const create$Overlay = () => {
   $TestOverlay.style.display = 'flex'
   $TestOverlay.style.gap = '10px'
   return $TestOverlay
-
-
 }
 
 const createAction = (action) => {
@@ -46,7 +45,6 @@ const createAction = (action) => {
   return $action
 }
 
-
 export const showOverlay = (state, background, text, actions = []) => {
   const $TestOverlay = create$Overlay()
   $TestOverlay.dataset.state = state
@@ -58,6 +56,7 @@ export const showOverlay = (state, background, text, actions = []) => {
   const $actions = actions.map(createAction)
   $TestOverlay.append(span, ...$actions)
   document.body.append($TestOverlay)
+  RendererWorkerTrace.scheduleExport()
 }
 
 export const showTestResults = (text: string): void => {
@@ -69,6 +68,7 @@ export const showTestResults = (text: string): void => {
   if (!existing) {
     document.body.append($TestResults)
   }
+  RendererWorkerTrace.scheduleExport()
 }
 
 export const performAction = async (locator, fnName, options) => {

--- a/packages/renderer-process/test/RendererWorkerTrace.test.ts
+++ b/packages/renderer-process/test/RendererWorkerTrace.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment jsdom
+ */
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import * as RendererWorkerTrace from '../src/parts/RendererWorkerTrace/RendererWorkerTrace.ts'
+
+beforeEach(() => {
+  document.body.replaceChildren()
+  RendererWorkerTrace.initialize('')
+})
+
+test('does not export a trace by default', () => {
+  RendererWorkerTrace.record('sent', 'Viewlet.show', [1])
+  RendererWorkerTrace.exportToDom()
+
+  expect(document.querySelector('.RendererWorkerTrace')).toBeNull()
+})
+
+test('exports sent and received renderer worker commands as json', () => {
+  RendererWorkerTrace.initialize('?traceRendererWorker=true')
+  const ipc = new EventTarget() as EventTarget & {
+    getData: (event: MessageEvent) => unknown
+  }
+  ipc.getData = (event): unknown => event.data
+  RendererWorkerTrace.listen({
+    dispose: jest.fn(async () => {}),
+    invoke: jest.fn(async () => {}),
+    invokeAndTransfer: jest.fn(async () => {}),
+    // @ts-expect-error The production rpc exposes its ipc connection at runtime.
+    ipc,
+    send: jest.fn(),
+  })
+
+  RendererWorkerTrace.record('sent', 'Layout.handleResize', [800, 600])
+  ipc.dispatchEvent(
+    new MessageEvent('message', {
+      data: {
+        method: 'Viewlet.executeCommands',
+        params: [1, ['div']],
+      },
+    }),
+  )
+  RendererWorkerTrace.exportToDom()
+
+  const script = document.querySelector<HTMLScriptElement>('script.RendererWorkerTrace')
+  expect(script?.type).toBe('application/json')
+  expect(JSON.parse(script?.textContent || '')).toEqual({
+    entries: [
+      {
+        direction: 'sent',
+        method: 'Layout.handleResize',
+        params: [800, 600],
+        timestamp: expect.any(Number),
+      },
+      {
+        direction: 'received',
+        method: 'Viewlet.executeCommands',
+        params: [1, ['div']],
+        timestamp: expect.any(Number),
+      },
+    ],
+    version: 1,
+  })
+})
+
+test('serializes transferables without including their bytes', () => {
+  RendererWorkerTrace.initialize('?traceRendererWorker=true')
+  RendererWorkerTrace.record('sent', 'Transferrable.transfer', [new Uint8Array(1024)])
+  RendererWorkerTrace.exportToDom()
+
+  const script = document.querySelector<HTMLScriptElement>('script.RendererWorkerTrace')
+  const trace = JSON.parse(script?.textContent || '')
+  expect(trace.entries[0].params).toEqual([
+    {
+      byteLength: 1024,
+      type: 'Uint8Array',
+    },
+  ])
+})


### PR DESCRIPTION
Adds opt-in renderer worker command tracing through the renderer process. Traces capture sent and received commands and are exposed as application/json after e2e tests finish.