### PR TITLE
fix: use transparent xterm background

### DIFF
--- a/packages/renderer-process/src/parts/ViewletTerminal2/ViewletTerminal2.ts
+++ b/packages/renderer-process/src/parts/ViewletTerminal2/ViewletTerminal2.ts
@@ -7,10 +7,14 @@ const defaultRows = 24
 const createTerminal = async () => {
   const [{ FitAddon }, { Terminal }] = await Promise.all([import('@xterm/addon-fit'), import('@xterm/xterm')])
   const terminal = new Terminal({
+    allowTransparency: true,
     cols: defaultColumns,
     convertEol: true,
     cursorBlink: true,
     rows: defaultRows,
+    theme: {
+      background: 'rgba(0, 0, 0, 0)',
+    },
   })
   const fitAddon = new FitAddon()
   terminal.loadAddon(fitAddon)

--- a/packages/renderer-process/test/ViewletTerminal2.test.ts
+++ b/packages/renderer-process/test/ViewletTerminal2.test.ts
@@ -142,10 +142,14 @@ test('setTerminal mounts and fits xterm', async () => {
 
   expect(terminal.opened).toBe(state.$Viewlet)
   expect(terminal.options).toMatchObject({
+    allowTransparency: true,
     cols: 80,
     convertEol: true,
     cursorBlink: true,
     rows: 24,
+    theme: {
+      background: 'rgba(0, 0, 0, 0)',
+    },
   })
   expect(terminal.addons).toEqual([fitAddon])
   expect(fitAddon.fitCalls).toBe(1)


### PR DESCRIPTION
Summary:
- render xterm with a transparent background
- let the editor panel supply the visible terminal background color