### PR TITLE
fix: prevent duplicate context menu backdrops

### DIFF
--- a/packages/renderer-process/src/parts/OldMenu/Menu.ts
+++ b/packages/renderer-process/src/parts/OldMenu/Menu.ts
@@ -188,7 +188,7 @@ const handleContextMenu = (event) => {
 }
 
 export const showMenu = (x, y, width, height, items, level, parentIndex = -1, dom = [], mouseBlocking = false) => {
-  if (mouseBlocking) {
+  if (mouseBlocking && !state.$BackDrop) {
     const $BackDrop = BackDrop.create$BackDrop()
     $BackDrop.onmousedown = handleBackDropMouseDown
     $BackDrop.oncontextmenu = handleContextMenu

--- a/packages/renderer-process/test/Menu.test.ts
+++ b/packages/renderer-process/test/Menu.test.ts
@@ -1,8 +1,8 @@
-// @ts-nocheck
-
 /**
  * @jest-environment jsdom
  */
+// @ts-nocheck
+
 import { beforeEach, expect, jest, test } from '@jest/globals'
 import * as AriaBoolean from '../src/parts/AriaBoolean/AriaBoolean.ts'
 import * as DomAttributeType from '../src/parts/DomAttributeType/DomAttributeType.ts'
@@ -524,6 +524,21 @@ test.skip('hideSubMenu - removes backdrop when closing last menu', () => {
   expect(Menu.state.$$Menus).toEqual([])
   expect(Menu.state.$BackDrop).toBeUndefined()
   expect(document.querySelector('.Menu')).toBeNull()
+  expect(document.querySelector('.BackDrop')).toBeNull()
+})
+
+test('showMenu reuses the backdrop when menu opens overlap', () => {
+  // @ts-ignore
+  RendererWorker.send.mockImplementation(() => {})
+
+  Menu.showMenu(0, 0, 100, 250, [], 0, -1, [], true)
+  Menu.showMenu(10, 10, 100, 250, [], 1, -1, [], true)
+
+  expect(document.querySelectorAll('.BackDrop')).toHaveLength(1)
+
+  Menu.hide(false)
+
+  expect(Menu.state.$BackDrop).toBeUndefined()
   expect(document.querySelector('.BackDrop')).toBeNull()
 })
 


### PR DESCRIPTION
Prevents overlapping context-menu opens from creating multiple backdrop nodes. Adds a DOM regression test that verifies the shared backdrop is removed when the menu closes.