### PR TITLE
fix: handle terminal tab actions

### DIFF
--- a/packages/renderer-process/src/parts/ViewletTerminals/ViewletTerminals.ts
+++ b/packages/renderer-process/src/parts/ViewletTerminals/ViewletTerminals.ts
@@ -1,6 +1,8 @@
 import * as VirtualDom from '../VirtualDom/VirtualDom.ts'
 import * as ViewletTerminalsEvents from './ViewletTerminalsEvents.ts'
 
+export const Events = ViewletTerminalsEvents
+
 export const create = () => {
   const $Viewlet = document.createElement('div')
   $Viewlet.className = 'Viewlet Terminals'

--- a/packages/renderer-process/src/parts/ViewletTerminals/ViewletTerminalsEvents.ts
+++ b/packages/renderer-process/src/parts/ViewletTerminals/ViewletTerminalsEvents.ts
@@ -1,10 +1,15 @@
 import * as ComponentUid from '../ComponentUid/ComponentUid.ts'
-import { getNodeIndex } from '../GetNodeIndex/GetNodeIndex.ts'
+import * as GetNodeIndex from '../GetNodeIndex/GetNodeIndex.ts'
 import * as ViewletTerminalsFunctions from './ViewletTerminalsFunctions.ts'
 
 export const handleClickTab = (event) => {
   const uid = ComponentUid.fromEvent(event)
   const { target } = event
-  const index = getNodeIndex(target)
-  ViewletTerminalsFunctions.handleClickTab(uid, index)
+  const tab = target.closest?.('.TerminalTab')
+  if (!tab) {
+    return
+  }
+  const index = GetNodeIndex.getNodeIndex(tab)
+  const shouldDelete = Boolean(target.closest?.('.TerminalTabDeleteButton'))
+  ViewletTerminalsFunctions.handleClickTab(uid, index, shouldDelete)
 }

--- a/packages/renderer-process/test/ViewletTerminalsEvents.test.ts
+++ b/packages/renderer-process/test/ViewletTerminalsEvents.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment jsdom
+ */
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import * as ComponentUid from '../src/parts/ComponentUid/ComponentUid.ts'
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+jest.unstable_mockModule('../src/parts/ViewletTerminals/ViewletTerminalsFunctions.ts', () => {
+  return {
+    handleClickTab: jest.fn(),
+  }
+})
+
+const ViewletTerminalsEvents = await import('../src/parts/ViewletTerminals/ViewletTerminalsEvents.ts')
+const ViewletTerminalsFunctions = await import('../src/parts/ViewletTerminals/ViewletTerminalsFunctions.ts')
+
+const createTerminals = () => {
+  const root = document.createElement('div')
+  root.className = 'TerminalTabs'
+  ComponentUid.set(root, 41)
+  root.addEventListener('click', ViewletTerminalsEvents.handleClickTab)
+
+  for (let i = 0; i < 2; i++) {
+    const tab = document.createElement('div')
+    tab.className = 'TerminalTab'
+    const icon = document.createElement('div')
+    icon.className = 'TerminalTabIcon'
+    const deleteButton = document.createElement('button')
+    deleteButton.className = 'TerminalTabDeleteButton'
+    const deleteIcon = document.createElement('div')
+    deleteIcon.className = 'MaskIcon MaskIconTrash'
+    deleteButton.append(deleteIcon)
+    tab.append(icon, deleteButton)
+    root.append(tab)
+  }
+
+  return root
+}
+
+test('clicking a terminal tab selects it', () => {
+  const root = createTerminals()
+  const icon = root.children[1].querySelector('.TerminalTabIcon') as HTMLElement
+
+  icon.click()
+
+  expect(ViewletTerminalsFunctions.handleClickTab).toHaveBeenCalledWith(41, 1, false)
+})
+
+test('clicking a terminal trash icon deletes its terminal', () => {
+  const root = createTerminals()
+  const deleteIcon = root.children[0].querySelector('.MaskIconTrash') as HTMLElement
+
+  deleteIcon.click()
+
+  expect(ViewletTerminalsFunctions.handleClickTab).toHaveBeenCalledWith(41, 0, true)
+})
+
+test('clicking outside a terminal tab does nothing', () => {
+  const root = createTerminals()
+
+  root.click()
+
+  expect(ViewletTerminalsFunctions.handleClickTab).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
Handle terminal tab selection and per-tab delete clicks through the functional DOM event path.