### PR TITLE
feature: add editor-only renderer export

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -20,7 +20,7 @@
       "project": ["src/**/*.ts"]
     },
     "packages/renderer-process": {
-      "entry": ["src/rendererProcessMain.ts", "src/xterm.ts", "test/**/*.test.ts"],
+      "entry": ["src/editorOnlyRendererProcessMain.ts", "src/rendererProcessMain.ts", "src/xterm.ts", "test/**/*.test.ts"],
       "project": ["src/**/*.ts", "test/**/*.ts"],
       "ignoreFiles": ["src/parts/**"],
       "ignoreIssues": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3783,14 +3783,14 @@
       }
     },
     "node_modules/@lvce-editor/rpc": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.11.0.tgz",
-      "integrity": "sha512-Hvte166d7Hjf8roIx5Z4ZRSS5sQZUEa7lkw20yjfp2MeOp4GQO9XAUL+2ca7J6wtPfIAYRlEL3av4YAYztoLIw==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.12.0.tgz",
+      "integrity": "sha512-qLaGwjenfbE/3e2LzOsPJazonyZ9GMHbOdYloBtNtzjdd3mre3lFIuCV4D8prq5P1quFiAlGRlgNCDPhb/G7Bg==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
         "@lvce-editor/command": "^2.0.0",
-        "@lvce-editor/ipc": "^16.4.0",
+        "@lvce-editor/ipc": "^16.6.0",
         "@lvce-editor/json-rpc": "^8.4.0",
         "@lvce-editor/verror": "^1.7.0"
       }
@@ -4017,9 +4017,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/virtual-dom": {
-      "version": "11.9.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/virtual-dom/-/virtual-dom-11.9.3.tgz",
-      "integrity": "sha512-ABr3H2/HEsEgLjkHM9PPwvp6t/HgS4IafHnzab4a2WMlWF9MW1OVFPbBhlgt4ncQBOshSQTuUcOZIp8O723cqg==",
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/virtual-dom/-/virtual-dom-11.10.0.tgz",
+      "integrity": "sha512-hqH9OSxfpWDaMLhIUwHC+wrdjBwfZlDHQvzsVJrdpJKaRmfD1LPL82KkdeMfTJqCFgaE0IUEdOW+gJEq2urM8w==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/web-socket-server": {
@@ -16866,8 +16866,8 @@
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.7.0",
-        "@lvce-editor/rpc": "^6.11.0",
-        "@lvce-editor/virtual-dom": "^11.9.3",
+        "@lvce-editor/rpc": "^6.12.0",
+        "@lvce-editor/virtual-dom": "^11.10.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0"
       },

--- a/packages/build/src/build.js
+++ b/packages/build/src/build.js
@@ -72,6 +72,16 @@ await bundleJs({
   external: [],
 })
 
+await bundleJs({
+  cwd: root,
+  from: 'packages/renderer-process/src/editorOnlyRendererProcessMain.ts',
+  platform: 'web',
+  outFile: '.tmp/dist/dist/editorOnlyRendererProcessMain.js',
+  external: [],
+})
+
+await cp(join(root, 'packages', 'renderer-process', 'static', 'editorOnly.css'), join(root, '.tmp', 'dist', 'dist', 'editorOnly.css'))
+
 const version = await getVersion()
 
 const packageJson = await readJson(join(root, 'packages', 'renderer-process', 'package.json'))

--- a/packages/renderer-process/src/editorOnlyRendererProcessMain.ts
+++ b/packages/renderer-process/src/editorOnlyRendererProcessMain.ts
@@ -1,0 +1,3 @@
+import * as EditorOnlyMain from './parts/EditorOnlyMain/EditorOnlyMain.ts'
+
+EditorOnlyMain.main()

--- a/packages/renderer-process/src/parts/EditorOnlyConfig/EditorOnlyConfig.ts
+++ b/packages/renderer-process/src/parts/EditorOnlyConfig/EditorOnlyConfig.ts
@@ -1,0 +1,26 @@
+export interface EditorOnlyConfig {
+  readonly content?: string
+  readonly fontFamily?: string
+  readonly fontSize?: number
+  readonly fontWeight?: number
+  readonly languageId?: string
+  readonly letterSpacing?: number
+  readonly lineNumbers?: boolean
+  readonly rowHeight?: number
+  readonly tabSize?: number
+  readonly tokenizePath?: string
+  readonly uri?: string
+}
+
+interface Config {
+  readonly editorOnly?: EditorOnlyConfig
+}
+
+export const getEditorOnlyConfig = (): EditorOnlyConfig => {
+  const configElement = document.getElementById('Config')
+  if (!configElement?.textContent) {
+    return {}
+  }
+  const config = JSON.parse(configElement.textContent) as Config
+  return config.editorOnly || {}
+}

--- a/packages/renderer-process/src/parts/EditorOnlyKeyBinding/EditorOnlyKeyBinding.ts
+++ b/packages/renderer-process/src/parts/EditorOnlyKeyBinding/EditorOnlyKeyBinding.ts
@@ -1,0 +1,62 @@
+const controlOrMeta = (event: KeyboardEvent): boolean => {
+  return event.ctrlKey || event.metaKey
+}
+
+const getShortcutCommand = (event: KeyboardEvent): string => {
+  if (!controlOrMeta(event)) {
+    return ''
+  }
+  switch (event.key.toLowerCase()) {
+    case 'a':
+      return 'selectAll'
+    case 'y':
+      return 'redo'
+    case 'z':
+      return event.shiftKey ? 'redo' : 'undo'
+    default:
+      return ''
+  }
+}
+
+const getHorizontalCommand = (event: KeyboardEvent): string => {
+  if (event.key === 'ArrowLeft') {
+    if (event.shiftKey) {
+      return 'selectCharacterLeft'
+    }
+    return controlOrMeta(event) ? 'cursorWordLeft' : 'cursorLeft'
+  }
+  if (event.key === 'ArrowRight') {
+    if (event.shiftKey) {
+      return 'selectCharacterRight'
+    }
+    return controlOrMeta(event) ? 'cursorWordRight' : 'cursorRight'
+  }
+  return ''
+}
+
+const getNavigationCommand = (event: KeyboardEvent): string => {
+  switch (event.key) {
+    case 'ArrowDown':
+      return event.shiftKey ? 'selectDown' : 'cursorDown'
+    case 'ArrowUp':
+      return event.shiftKey ? 'selectUp' : 'cursorUp'
+    case 'Backspace':
+      return controlOrMeta(event) ? 'deleteWordLeft' : 'deleteLeft'
+    case 'Delete':
+      return controlOrMeta(event) ? 'deleteWordRight' : 'deleteRight'
+    case 'End':
+      return 'cursorEnd'
+    case 'Home':
+      return 'cursorHome'
+    case 'PageDown':
+      return 'cursorPageDown'
+    case 'Tab':
+      return 'handleTab'
+    default:
+      return ''
+  }
+}
+
+export const getEditorCommand = (event: KeyboardEvent): string => {
+  return getShortcutCommand(event) || getHorizontalCommand(event) || getNavigationCommand(event)
+}

--- a/packages/renderer-process/src/parts/EditorOnlyMain/EditorOnlyMain.ts
+++ b/packages/renderer-process/src/parts/EditorOnlyMain/EditorOnlyMain.ts
@@ -1,0 +1,194 @@
+import { ModuleWorkerWithMessagePortRpcParent, PlainMessagePortRpc, type Rpc } from '@lvce-editor/rpc'
+import * as commandMapRef from '../CommandMapRef/CommandMapRef.ts'
+import * as EditorOnlyConfig from '../EditorOnlyConfig/EditorOnlyConfig.ts'
+import * as EditorOnlyKeyBinding from '../EditorOnlyKeyBinding/EditorOnlyKeyBinding.ts'
+import * as EditorOnlyViewlet from '../EditorOnlyViewlet/EditorOnlyViewlet.ts'
+import * as EditorWorkerUrl from '../EditorWorkerUrl/EditorWorkerUrl.ts'
+import * as PlatformType from '../PlatformType/PlatformType.ts'
+import * as SyntaxHighlightingWorkerUrl from '../SyntaxHighlightingWorkerUrl/SyntaxHighlightingWorkerUrl.ts'
+import * as VirtualDom from '../VirtualDom/VirtualDom.ts'
+
+const editorUid = 1
+
+interface TypingBenchmarkApi {
+  readonly focus: () => void
+  readonly getText: () => string
+}
+
+declare global {
+  interface Window {
+    __typingBenchmark?: TypingBenchmarkApi
+  }
+}
+
+const getCharWidth = (fontFamily: string, fontSize: number, fontWeight: number): number => {
+  const canvas = document.createElement('canvas')
+  const context = canvas.getContext('2d')
+  if (!context) {
+    return 9
+  }
+  context.font = `${fontWeight} ${fontSize}px ${fontFamily}`
+  return context.measureText('a').width
+}
+
+const launchWorker = async (name: string, url: string, commandMap: Record<string, (...args: any[]) => unknown>): Promise<Rpc> => {
+  const { port1, port2 } = new MessageChannel()
+  await ModuleWorkerWithMessagePortRpcParent.create({
+    commandMap: {},
+    name,
+    port: port1,
+    url,
+  })
+  return PlainMessagePortRpc.create({
+    commandMap,
+    messagePort: port2,
+  })
+}
+
+const getBounds = () => {
+  return {
+    height: window.innerHeight,
+    width: window.innerWidth,
+    x: 0,
+    y: 0,
+  }
+}
+
+const getEditorMethod = (command: string): string => {
+  return command.includes('.') ? command : `Editor.${command}`
+}
+
+const render = async (editorRpc: Rpc): Promise<void> => {
+  const diffResult = await editorRpc.invoke('Editor.diff2', editorUid)
+  const commands = await editorRpc.invoke('Editor.render2', editorUid, diffResult)
+  EditorOnlyViewlet.executeCommands(commands)
+}
+
+const focus = (): void => {
+  const input = document.querySelector<HTMLTextAreaElement>('.EditorInput textarea')
+  input?.focus()
+}
+
+const markRendered = async (): Promise<void> => {
+  await new Promise<void>((resolve) => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => resolve())
+    })
+  })
+  performance.mark('syntax-highlight-rendered')
+  document.documentElement.dataset.renderBenchmarkReady = 'true'
+}
+
+const setError = (error: unknown): void => {
+  document.documentElement.dataset.benchmarkReady = 'error'
+  document.body.textContent = error instanceof Error ? error.stack || error.message : String(error)
+}
+
+export const main = async (): Promise<void> => {
+  document.documentElement.dataset.benchmarkStage = 'starting'
+  try {
+    document.documentElement.dataset.benchmarkStage = 'launching-syntax-worker'
+    const syntaxHighlightingRpc = await launchWorker('Syntax Highlighting Worker', SyntaxHighlightingWorkerUrl.syntaxHighlightingWorkerUrl, {})
+    Object.assign(commandMapRef.commandMapRef, {
+      'Main.handleModifiedStatusChange': () => undefined,
+      'SendMessagePortToSyntaxHighlightingWorker.sendMessagePortToSyntaxHighlightingWorker': async (
+        port: MessagePort,
+        initialCommand: string,
+      ): Promise<void> => {
+        document.documentElement.dataset.benchmarkStage = 'connecting-syntax-worker'
+        await syntaxHighlightingRpc.invokeAndTransfer(initialCommand, port)
+        document.documentElement.dataset.benchmarkStage = 'syntax-worker-connected'
+      },
+    })
+
+    document.documentElement.dataset.benchmarkStage = 'launching-editor-worker'
+    const editorRpc = await launchWorker('Editor Worker', EditorWorkerUrl.editorWorkerUrl, commandMapRef.commandMapRef)
+    document.documentElement.dataset.benchmarkStage = 'initializing-editor-worker'
+    await editorRpc.invoke('Initialize.initialize', true, true)
+
+    document.documentElement.dataset.benchmarkStage = 'creating-editor'
+    const config = EditorOnlyConfig.getEditorOnlyConfig()
+    const fontFamily = config.fontFamily || 'monospace'
+    const fontSize = config.fontSize || 15
+    const fontWeight = config.fontWeight || 400
+    const bounds = getBounds()
+    await editorRpc.invoke('Editor.createStandalone', {
+      assetDir: '',
+      charWidth: getCharWidth(fontFamily, fontSize, fontWeight),
+      content: config.content || '',
+      fontFamily,
+      fontSize,
+      fontWeight,
+      ...bounds,
+      id: editorUid,
+      languageId: config.languageId || 'plaintext',
+      letterSpacing: config.letterSpacing || 0,
+      lineNumbers: config.lineNumbers || false,
+      platform: PlatformType.Web,
+      rowHeight: config.rowHeight || 20,
+      tabSize: config.tabSize || 2,
+      tokenizePath: config.tokenizePath || '',
+      uri: config.uri || 'file:///standalone.txt',
+    })
+
+    document.documentElement.dataset.benchmarkStage = 'rendering-editor'
+    EditorOnlyViewlet.create(editorUid)
+    const listeners = await editorRpc.invoke('Editor.renderEventListeners')
+    EditorOnlyViewlet.registerEventListeners(editorUid, listeners)
+
+    let text = config.content || ''
+    let pending = Promise.resolve()
+    const executeQueued = async (previous: Promise<void>, command: string, args: readonly any[]): Promise<void> => {
+      try {
+        await previous
+        await editorRpc.invoke(getEditorMethod(command), editorUid, ...args)
+        await render(editorRpc)
+        text = await editorRpc.invoke('Editor.getText', editorUid)
+      } catch (error) {
+        setError(error)
+      }
+    }
+    const execute = (command: string, ...args: readonly any[]): void => {
+      pending = executeQueued(pending, command, args)
+    }
+    VirtualDom.setIpc({
+      send(method: string, uid: number, command: string, ...args: readonly any[]): void {
+        if (method !== 'Viewlet.executeViewletCommand' || uid !== editorUid) {
+          throw new Error(`Unsupported editor-only event: ${method}`)
+        }
+        execute(command, ...args)
+      },
+    })
+
+    document.addEventListener(
+      'keydown',
+      (event) => {
+        const command = EditorOnlyKeyBinding.getEditorCommand(event)
+        if (!command) {
+          return
+        }
+        event.preventDefault()
+        execute(command)
+      },
+      { capture: true },
+    )
+    window.addEventListener('resize', () => {
+      execute('resize', getBounds())
+    })
+
+    await render(editorRpc)
+    Object.defineProperty(window, '__typingBenchmark', {
+      configurable: true,
+      value: {
+        focus,
+        getText: () => text,
+      },
+    })
+    focus()
+    await markRendered()
+    document.documentElement.dataset.benchmarkReady = 'true'
+    document.documentElement.dataset.benchmarkStage = 'ready'
+  } catch (error) {
+    setError(error)
+  }
+}

--- a/packages/renderer-process/src/parts/EditorOnlyViewlet/EditorOnlyViewlet.ts
+++ b/packages/renderer-process/src/parts/EditorOnlyViewlet/EditorOnlyViewlet.ts
@@ -1,0 +1,107 @@
+import { applyPatch, getViewletInstance, registerEventListeners, rememberFocus, setComponentUid, setViewletInstance } from '@lvce-editor/virtual-dom'
+import * as Css from '../Css/Css.ts'
+
+const ignoreCommand = (): void => {}
+
+const getElement = (uid: number): HTMLElement => {
+  const instance = getViewletInstance(uid)
+  const element = instance?.state?.$Viewlet
+  if (!(element instanceof HTMLElement)) {
+    throw new TypeError(`Editor element ${uid} not found`)
+  }
+  return element
+}
+
+const create = (uid: number): void => {
+  const element = document.createElement('div')
+  setComponentUid(element, uid)
+  setViewletInstance(uid, {
+    factory: {},
+    state: {
+      $Viewlet: element,
+    },
+  })
+  document.body.append(element)
+}
+
+const dispose = (uid: number): void => {
+  getElement(uid).remove()
+  setViewletInstance(uid, undefined)
+}
+
+const focusSelector = (uid: number, selector: string): void => {
+  const element = getElement(uid).querySelector<HTMLElement>(selector)
+  element?.focus()
+}
+
+const setBounds = (uid: number, left: number, top: number, width: number, height: number): void => {
+  const element = getElement(uid)
+  element.style.left = `${left}px`
+  element.style.top = `${top}px`
+  element.style.width = `${width}px`
+  element.style.height = `${height}px`
+}
+
+const setPatches = (uid: number, patches: readonly any[]): void => {
+  const element = getElement(uid)
+  if (patches.length === 1 && patches[0].type === 6) {
+    const replacement = rememberFocus(element, patches[0].nodes, {}, uid)
+    setComponentUid(replacement, uid)
+    const instance = getViewletInstance(uid)
+    setViewletInstance(uid, {
+      ...instance,
+      state: {
+        ...instance.state,
+        $Viewlet: replacement,
+      },
+    })
+    return
+  }
+  applyPatch(element, patches, {}, uid)
+}
+
+const setSelectionByName = (uid: number, name: string, start: number, end: number): void => {
+  const input = getElement(uid).querySelector<HTMLInputElement>(`[name="${CSS.escape(name)}"]`)
+  if (!input) {
+    return
+  }
+  input.selectionStart = start
+  input.selectionEnd = end
+}
+
+const setUid = (uid: number, componentUid: number): void => {
+  setComponentUid(getElement(uid), componentUid)
+}
+
+const setValueByName = (uid: number, name: string, value: string): void => {
+  const input = getElement(uid).querySelector<HTMLInputElement>(`[name="${CSS.escape(name)}"]`)
+  if (input) {
+    input.value = value
+  }
+}
+
+const commandHandlers: Record<string, (...args: any[]) => unknown> = {
+  'Viewlet.dispose': dispose,
+  'Viewlet.focusSelector': focusSelector,
+  'Viewlet.setAdditionalFocus': ignoreCommand,
+  'Viewlet.setBounds': setBounds,
+  'Viewlet.setCss': Css.addCssStyleSheet,
+  'Viewlet.setFocusContext': ignoreCommand,
+  'Viewlet.setPatches': setPatches,
+  'Viewlet.setSelectionByName': setSelectionByName,
+  'Viewlet.setUid': setUid,
+  'Viewlet.setValueByName': setValueByName,
+  'Viewlet.unsetAdditionalFocus': ignoreCommand,
+}
+
+export const executeCommands = (commands: readonly (readonly any[])[]): void => {
+  for (const [command, ...args] of commands) {
+    const handler = commandHandlers[command]
+    if (!handler) {
+      throw new Error(`Unsupported editor-only render command: ${command}`)
+    }
+    handler(...args)
+  }
+}
+
+export { create, registerEventListeners }

--- a/packages/renderer-process/static/editorOnly.css
+++ b/packages/renderer-process/static/editorOnly.css
@@ -1,0 +1,191 @@
+:root {
+  --EditorCursorBackground: #aeafad;
+  --EditorFontFamily: monospace;
+  --EditorFontFeatureSettings: normal;
+  --EditorFontSize: 15px;
+  --EditorFontWeight: 400;
+  --EditorLetterSpacing: 0;
+  --EditorLineHeight: 20px;
+  --EditorSelectionBackground: #264f78;
+  --EditorTabSize: 2;
+  --MainBackground: #1e1e1e;
+}
+
+html,
+body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+  background: var(--MainBackground);
+}
+
+.Viewlet {
+  contain: strict;
+}
+
+.Editor {
+  width: 100%;
+  height: 100%;
+  background: var(--MainBackground);
+  color: #d4d4d4;
+  outline: none;
+  border: none;
+  font-family: var(--EditorFontFamily);
+  white-space: pre;
+  font-size: var(--EditorFontSize);
+  letter-spacing: var(--EditorLetterSpacing);
+  font-feature-settings: var(--EditorFontFeatureSettings);
+  tab-size: var(--EditorTabSize);
+  cursor: text;
+  font-weight: var(--EditorFontWeight);
+  display: flex;
+}
+
+.EditorContent,
+.EditorLayers,
+.EditorRows {
+  contain: strict;
+  width: 100%;
+  height: 100%;
+}
+
+.EditorRows {
+  white-space: pre;
+}
+
+.EditorRow {
+  display: block;
+  height: var(--EditorLineHeight);
+  line-height: var(--EditorLineHeight);
+  contain: strict;
+}
+
+.Editors {
+  flex: 1;
+}
+
+.EditorCursor {
+  width: 2px;
+  height: var(--EditorLineHeight);
+  position: absolute;
+  top: 0;
+  left: 0;
+  background: var(--EditorCursorBackground);
+  pointer-events: none;
+  contain: strict;
+}
+
+.EditorInput {
+  position: absolute;
+  width: 0;
+  height: 0;
+  opacity: 0;
+  padding: 0;
+  border: 0;
+  font-size: 1px;
+  top: -9999px;
+  left: -9999px;
+}
+
+.EditorSelection {
+  position: absolute;
+  top: 0;
+  left: 0;
+  pointer-events: none;
+  background: var(--EditorSelectionBackground);
+}
+
+.Token {
+  contain: content;
+}
+
+.TokenComment {
+  color: #6a9955;
+}
+
+.TokenString,
+.TokenStringValue {
+  color: #ce9178;
+}
+
+.TokenNumeric,
+.TokenNumber {
+  color: #b5cea8;
+}
+
+.TokenKeyword,
+.TokenTag,
+.TokenTagName {
+  color: #569cd6;
+}
+
+.TokenAttribute,
+.TokenAttributeName,
+.TokenProperty,
+.TokenPropertyName {
+  color: #9cdcfe;
+}
+
+.TokenPunctuation,
+.TokenPunctuationTag {
+  color: #808080;
+}
+
+.LayerCursor,
+.LayerDiagnostics {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.Gutter {
+  contain: strict;
+  width: 30px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.Gutter:empty {
+  display: none;
+}
+
+.LineNumber {
+  color: rgba(155, 162, 160, 0.6);
+  contain: strict;
+  margin-right: 1px;
+  height: var(--EditorLineHeight);
+  text-align: right;
+}
+
+.ScrollBar {
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 14px;
+  bottom: 0;
+  contain: strict;
+  cursor: default;
+}
+
+.ScrollBarHorizontal {
+  left: 0;
+  top: auto;
+  height: 14px;
+  width: auto;
+}
+
+.ScrollBarThumb {
+  width: 100%;
+  position: absolute;
+  contain: strict;
+  background: rgba(57, 71, 71, 0.6);
+  height: var(--ScrollBarThumbHeight);
+  top: var(--ScrollBarThumbTop);
+}
+
+.ScrollBarThumbHorizontal {
+  height: 100%;
+  width: auto;
+}

--- a/packages/renderer-process/test/EditorOnlyConfig.test.ts
+++ b/packages/renderer-process/test/EditorOnlyConfig.test.ts
@@ -1,0 +1,31 @@
+/**
+ * @jest-environment jsdom
+ */
+import { beforeEach, expect, test } from '@jest/globals'
+import { getEditorOnlyConfig } from '../src/parts/EditorOnlyConfig/EditorOnlyConfig.ts'
+
+beforeEach(() => {
+  document.body.replaceChildren()
+})
+
+test('returns the standalone editor configuration', () => {
+  const config = document.createElement('script')
+  config.id = 'Config'
+  config.type = 'application/json'
+  config.textContent = JSON.stringify({
+    editorOnly: {
+      content: '<h1>Hello</h1>',
+      languageId: 'html',
+    },
+  })
+  document.body.append(config)
+
+  expect(getEditorOnlyConfig()).toEqual({
+    content: '<h1>Hello</h1>',
+    languageId: 'html',
+  })
+})
+
+test('returns an empty configuration when no config exists', () => {
+  expect(getEditorOnlyConfig()).toEqual({})
+})

--- a/packages/renderer-process/test/EditorOnlyKeyBinding.test.ts
+++ b/packages/renderer-process/test/EditorOnlyKeyBinding.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from '@jest/globals'
+import { getEditorCommand } from '../src/parts/EditorOnlyKeyBinding/EditorOnlyKeyBinding.ts'
+
+const event = (key: string, options: Partial<KeyboardEvent> = {}): KeyboardEvent => {
+  return {
+    altKey: false,
+    ctrlKey: false,
+    key,
+    metaKey: false,
+    shiftKey: false,
+    ...options,
+  } as KeyboardEvent
+}
+
+test('maps cursor movement directly to editor worker commands', () => {
+  expect(getEditorCommand(event('ArrowLeft'))).toBe('cursorLeft')
+  expect(getEditorCommand(event('ArrowRight', { ctrlKey: true }))).toBe('cursorWordRight')
+  expect(getEditorCommand(event('ArrowDown', { shiftKey: true }))).toBe('selectDown')
+  expect(getEditorCommand(event('Home'))).toBe('cursorHome')
+})
+
+test('maps editing shortcuts directly to editor worker commands', () => {
+  expect(getEditorCommand(event('a', { ctrlKey: true }))).toBe('selectAll')
+  expect(getEditorCommand(event('z', { ctrlKey: true }))).toBe('undo')
+  expect(getEditorCommand(event('z', { ctrlKey: true, shiftKey: true }))).toBe('redo')
+  expect(getEditorCommand(event('Tab'))).toBe('handleTab')
+  expect(getEditorCommand(event('Backspace'))).toBe('deleteLeft')
+  expect(getEditorCommand(event('Delete', { ctrlKey: true }))).toBe('deleteWordRight')
+})
+
+test('ignores text input handled by beforeinput', () => {
+  expect(getEditorCommand(event('a'))).toBe('')
+})

--- a/packages/renderer-process/test/EditorOnlyViewlet.test.ts
+++ b/packages/renderer-process/test/EditorOnlyViewlet.test.ts
@@ -1,0 +1,28 @@
+/**
+ * @jest-environment jsdom
+ */
+import { beforeEach, expect, test } from '@jest/globals'
+import * as EditorOnlyViewlet from '../src/parts/EditorOnlyViewlet/EditorOnlyViewlet.ts'
+
+beforeEach(() => {
+  document.body.replaceChildren()
+})
+
+test('creates only the editor root and applies its bounds', () => {
+  EditorOnlyViewlet.create(701)
+  EditorOnlyViewlet.executeCommands([
+    ['Viewlet.setBounds', 701, 0, 0, 800, 600],
+    ['Viewlet.setFocusContext', 701, 12],
+  ])
+
+  expect(document.body.children).toHaveLength(1)
+  const element = document.body.firstElementChild as HTMLElement
+  expect(element.style.width).toBe('800px')
+  expect(element.style.height).toBe('600px')
+})
+
+test('rejects workbench render commands', () => {
+  expect(() => EditorOnlyViewlet.executeCommands([['Viewlet.createPlaceholder', 'ActivityBar']])).toThrow(
+    'Unsupported editor-only render command: Viewlet.createPlaceholder',
+  )
+})


### PR DESCRIPTION
## Summary
- add an editor-only renderer entrypoint and stylesheet
- connect the renderer process directly to editor and syntax-highlighting workers over message ports
- render only the editor DOM with direct input, cursor, selection, resize, and benchmark readiness handling
- export the additional static bundle during builds

## Validation
- `npm run lint`
- `npm run type-check`
- `npm test`
- `npm run build`
- browser typing/cursor/resize/syntax-highlight smoke test