### PR TITLE
fix: support Command keybindings on macOS

### DIFF
--- a/packages/renderer-process/src/parts/GetKeyBindingIdentifier/GetKeyBindingIdentifier.ts
+++ b/packages/renderer-process/src/parts/GetKeyBindingIdentifier/GetKeyBindingIdentifier.ts
@@ -2,8 +2,8 @@ import { KeyModifier, GetKeyCode } from '@lvce-editor/constants'
 import * as NormalizeKey from '../NormalizeKey/NormalizeKey.ts'
 
 export const getKeyBindingIdentifier = (event: KeyboardEvent): number => {
-  const { altKey, code, ctrlKey, key, shiftKey } = event
-  const modifierControl = ctrlKey ? KeyModifier.CtrlCmd : 0
+  const { altKey, code, ctrlKey, key, metaKey, shiftKey } = event
+  const modifierControl = ctrlKey || metaKey ? KeyModifier.CtrlCmd : 0
   const modifierShift = shiftKey ? KeyModifier.Shift : 0
   const modifierAlt = altKey ? KeyModifier.Alt : 0
   const normalizedKey = NormalizeKey.normalizeKey(key, code)

--- a/packages/renderer-process/test/GetKeyBindingIdentifier.test.ts
+++ b/packages/renderer-process/test/GetKeyBindingIdentifier.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@jest/globals'
 import * as GetKeyBindingIdenfitier from '../src/parts/GetKeyBindingIdentifier/GetKeyBindingIdentifier.ts'
 import * as KeyCode from '../src/parts/KeyCode/KeyCode.ts'
+import * as KeyModifier from '../src/parts/KeyModifier/KeyModifier.ts'
 
 test('KeyA', () => {
   const event = {
@@ -20,4 +21,15 @@ test('KeyB', () => {
     shiftKey: false,
   } as any
   expect(GetKeyBindingIdenfitier.getKeyBindingIdentifier(event)).toBe(KeyCode.KeyB)
+})
+
+test('Command KeyA', () => {
+  const event = {
+    altKey: false,
+    ctrlKey: false,
+    key: 'a',
+    metaKey: true,
+    shiftKey: false,
+  } as any
+  expect(GetKeyBindingIdenfitier.getKeyBindingIdentifier(event)).toBe(KeyModifier.CtrlCmd | KeyCode.KeyA)
 })


### PR DESCRIPTION
Map the native Command modifier to the portable CtrlCmd keybinding modifier, so bindings such as Command-Shift-P work on macOS while Control bindings remain supported elsewhere.