### PR TITLE
fix: expose current viewlet drag data

### DIFF
--- a/packages/renderer-process/src/parts/CommandMap/CommandMap.ts
+++ b/packages/renderer-process/src/parts/CommandMap/CommandMap.ts
@@ -102,6 +102,7 @@ export const commandMap = {
   'Viewlet.focus': Viewlet.focus,
   'Viewlet.focusElementByName': Viewlet.focusElementByName,
   'Viewlet.focusSelector': Viewlet.focusSelector,
+  'Viewlet.getDragData': Viewlet.getDragData,
   'Viewlet.handleError': Viewlet.handleError,
   'Viewlet.invoke': Viewlet.invoke,
   'Viewlet.loadModule': Viewlet.loadModule,

--- a/packages/renderer-process/src/parts/DragInfo/DragInfo.ts
+++ b/packages/renderer-process/src/parts/DragInfo/DragInfo.ts
@@ -1,9 +1,16 @@
 import { getDragInfo, setDragInfo } from '@lvce-editor/virtual-dom'
 
+let currentDragInfo: any
+
 export const set = (id: string | number, data: any) => {
+  currentDragInfo = data
   setDragInfo(id, data)
 }
 
 export const get = (id: string | number) => {
   return getDragInfo(id)
+}
+
+export const getCurrent = (): any => {
+  return currentDragInfo
 }

--- a/packages/renderer-process/src/parts/DragInfo/DragInfo.ts
+++ b/packages/renderer-process/src/parts/DragInfo/DragInfo.ts
@@ -1,9 +1,11 @@
 import { getDragInfo, setDragInfo } from '@lvce-editor/virtual-dom'
 
-let currentDragInfo: any
+const state: { currentDragInfo: any } = {
+  currentDragInfo: undefined,
+}
 
 export const set = (id: string | number, data: any) => {
-  currentDragInfo = data
+  state.currentDragInfo = data
   setDragInfo(id, data)
 }
 
@@ -12,5 +14,5 @@ export const get = (id: string | number) => {
 }
 
 export const getCurrent = (): any => {
-  return currentDragInfo
+  return state.currentDragInfo
 }

--- a/packages/renderer-process/src/parts/Viewlet/Viewlet.ts
+++ b/packages/renderer-process/src/parts/Viewlet/Viewlet.ts
@@ -266,6 +266,10 @@ const setDragData = (viewletId: number, dragData: any): void => {
   DragInfo.set(viewletId, dragData)
 }
 
+export const getDragData = (): any => {
+  return DragInfo.getCurrent()
+}
+
 const setDom = (viewletId, dom) => {
   const instance = getViewletInstance(viewletId)
   if (!instance) {

--- a/packages/renderer-process/test/Viewlet.test.ts
+++ b/packages/renderer-process/test/Viewlet.test.ts
@@ -119,3 +119,19 @@ test('setDom2 preserves focused input state', () => {
   expect(updatedInput?.className).toBe('MultilineInputBox after')
   expect(updatedInput?.placeholder).toBe('Find in file')
 })
+
+test('getDragData returns the latest registered drag data', () => {
+  const dragData = {
+    items: [
+      {
+        data: 'file:///workspace/file.txt',
+        type: 'text/uri-list',
+      },
+    ],
+    label: '1',
+  }
+
+  Viewlet.executeCommands([['Viewlet.setDragData', 42, dragData]])
+
+  expect(Viewlet.getDragData()).toBe(dragData)
+})


### PR DESCRIPTION
Retain and expose the latest viewlet drag payload so worker consumers can resolve internal drag data that Chromium hides behind an opaque token.