### PR TITLE
fix: execute terminal panel actions

### DIFF
--- a/packages/renderer-process/src/parts/ViewletPanel/ViewletPanelEvents.ts
+++ b/packages/renderer-process/src/parts/ViewletPanel/ViewletPanelEvents.ts
@@ -17,7 +17,7 @@ const handleClickTab = (target, uid) => {
   ViewletPanelFunctions.selectIndex(uid, index)
 }
 
-const handleClickAction = (target, uid) => {
+const handleClickAction = (target) => {
   const index = GetNodeIndex.getNodeIndex(target)
   const { command } = target.dataset
   if (!command) {
@@ -25,7 +25,8 @@ const handleClickAction = (target, uid) => {
     console.info('[panel] action command not found')
     return
   }
-  ViewletPanelFunctions.handleClickAction(uid, index, command)
+  const childUid = ComponentUid.get(target)
+  ViewletPanelFunctions.handleClickAction(childUid, index, command)
 }
 
 export const handleHeaderClick = (event) => {
@@ -37,7 +38,7 @@ export const handleHeaderClick = (event) => {
   }
   const action = target.closest?.('.IconButton[data-command]')
   if (action) {
-    handleClickAction(action, uid)
+    handleClickAction(action)
   }
 }
 

--- a/packages/renderer-process/src/parts/ViewletTerminals/ViewletTerminalsEvents.ts
+++ b/packages/renderer-process/src/parts/ViewletTerminals/ViewletTerminalsEvents.ts
@@ -13,3 +13,17 @@ export const handleClickTab = (event) => {
   const shouldDelete = Boolean(target.closest?.('.TerminalTabDeleteButton'))
   ViewletTerminalsFunctions.handleClickTab(uid, index, shouldDelete)
 }
+
+export const handleMouseDown = (event) => {
+  const uid = ComponentUid.fromEvent(event)
+  const { target } = event
+  const terminal = target.closest?.('.XtermTerminal')
+  if (!terminal) {
+    return
+  }
+  const terminalUid = ComponentUid.get(terminal)
+  if (!terminalUid) {
+    return
+  }
+  ViewletTerminalsFunctions.handleMouseDown(uid, terminalUid)
+}

--- a/packages/renderer-process/test/ViewletTerminalsEvents.test.ts
+++ b/packages/renderer-process/test/ViewletTerminalsEvents.test.ts
@@ -11,6 +11,7 @@ beforeEach(() => {
 jest.unstable_mockModule('../src/parts/ViewletTerminals/ViewletTerminalsFunctions.ts', () => {
   return {
     handleClickTab: jest.fn(),
+    handleMouseDown: jest.fn(),
   }
 })
 
@@ -64,4 +65,30 @@ test('clicking outside a terminal tab does nothing', () => {
   root.click()
 
   expect(ViewletTerminalsFunctions.handleClickTab).not.toHaveBeenCalled()
+})
+
+test('pressing a terminal marks it as the active terminal', () => {
+  const root = document.createElement('div')
+  ComponentUid.set(root, 41)
+  root.addEventListener('mousedown', ViewletTerminalsEvents.handleMouseDown)
+  const terminal = document.createElement('div')
+  terminal.className = 'XtermTerminal'
+  ComponentUid.set(terminal, 42)
+  const xtermScreen = document.createElement('div')
+  terminal.append(xtermScreen)
+  root.append(terminal)
+
+  xtermScreen.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+
+  expect(ViewletTerminalsFunctions.handleMouseDown).toHaveBeenCalledWith(41, 42)
+})
+
+test('pressing outside a terminal does not change the active terminal', () => {
+  const root = document.createElement('div')
+  ComponentUid.set(root, 41)
+  root.addEventListener('mousedown', ViewletTerminalsEvents.handleMouseDown)
+
+  root.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+
+  expect(ViewletTerminalsFunctions.handleMouseDown).not.toHaveBeenCalled()
 })


### PR DESCRIPTION
Summary:
- execute panel header actions on the active child viewlet
- forward terminal presses so split-terminal focus stays in sync