### PR TITLE
fix: synchronize root dependency lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3758,14 +3758,14 @@
       }
     },
     "node_modules/@lvce-editor/rpc": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.14.0.tgz",
-      "integrity": "sha512-6B86mcoXEZQ1EN/HbQ29n0woY08uMQnaGde0ugComuFKA4g3eqYhF/unwyw2Ggw8kEFRslYkFN77W2LA2MrjCw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.15.0.tgz",
+      "integrity": "sha512-+LP6NFwCNPH2SUWrM72NQqUGW8IQ5NgWkuHQloN4Ea1AWoXUmVsgydN7ZZyUDstLIHUiA32conqOy0ujCHzEGw==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
         "@lvce-editor/command": "^2.0.0",
-        "@lvce-editor/ipc": "^16.7.0",
+        "@lvce-editor/ipc": "^16.9.0",
         "@lvce-editor/json-rpc": "^8.4.0",
         "@lvce-editor/verror": "^1.7.0"
       }
@@ -3992,9 +3992,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/virtual-dom": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/virtual-dom/-/virtual-dom-11.11.0.tgz",
-      "integrity": "sha512-BHweDCmHmYCInds3OHyTdwJmLiTqF202ulZkZxqhaZj1MvNWk2ZxB+8tzc2L8W3pAdow2JFcjKH2pcBSZ5ZOXg==",
+      "version": "11.11.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/virtual-dom/-/virtual-dom-11.11.3.tgz",
+      "integrity": "sha512-hJD3mqM53N/uDzS7G9xzG/Al1ZRcEkyXkgMIhumdIddT67tr8H0OAeAN+27QKP3e9v8kP8VJW7j1va5yiY7scw==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/web-socket-server": {
@@ -16649,8 +16649,8 @@
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.7.0",
-        "@lvce-editor/rpc": "^6.14.0",
-        "@lvce-editor/virtual-dom": "^11.11.0",
+        "@lvce-editor/rpc": "^6.15.0",
+        "@lvce-editor/virtual-dom": "^11.11.3",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0"
       },


### PR DESCRIPTION
## Summary

- synchronize the root workspace lockfile with the renderer-process manifest
- bundle virtual-dom 11.11.3 so focused elements receive updated ARIA attributes
- also synchronize the already-declared RPC 6.15.0 dependency

## Validation

- clean root `npm ci`
- `npm run build` and verified generated bundle contains `updateAttributes`
- `npm test` (66 suites, 209 tests)
- `npm run type-check`
- `npm run lint`
- `git diff --check`