### PR TITLE
fix: synchronize root dependency lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3736,9 +3736,9 @@
       }
     },
     "node_modules/@lvce-editor/rpc": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.15.0.tgz",
-      "integrity": "sha512-+LP6NFwCNPH2SUWrM72NQqUGW8IQ5NgWkuHQloN4Ea1AWoXUmVsgydN7ZZyUDstLIHUiA32conqOy0ujCHzEGw==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.16.0.tgz",
+      "integrity": "sha512-NK9k9/L3fWhwy3j3zrG0ffqHE+9SZ7DevvKcTkrrbgKAS3/L/pAJsTI9MuD8F+18oJEncjCmFTr26+CK3aPSgA==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
@@ -3970,9 +3970,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/virtual-dom": {
-      "version": "11.11.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/virtual-dom/-/virtual-dom-11.11.3.tgz",
-      "integrity": "sha512-hJD3mqM53N/uDzS7G9xzG/Al1ZRcEkyXkgMIhumdIddT67tr8H0OAeAN+27QKP3e9v8kP8VJW7j1va5yiY7scw==",
+      "version": "11.11.4",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/virtual-dom/-/virtual-dom-11.11.4.tgz",
+      "integrity": "sha512-tL9A23DRsRt8DEPDnd5x0DNF4uAZo9rDYi5ifjdyvtKO2bFHsUfcPBN82y1vJJqhGZbOlO1kUm3416+A/FCUYg==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/web-socket-server": {
@@ -16610,8 +16610,8 @@
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.7.0",
-        "@lvce-editor/rpc": "^6.15.0",
-        "@lvce-editor/virtual-dom": "^11.11.3",
+        "@lvce-editor/rpc": "^6.16.0",
+        "@lvce-editor/virtual-dom": "^11.11.4",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0"
       },


### PR DESCRIPTION
## Summary

- synchronize the root lockfile with the renderer-process RPC and virtual-DOM dependencies already declared on main
- restore clean root `npm ci` installs after #753 and #754

## Validation

- `npm ci`
- `npm test` (66 suites, 209 tests passed)
- `npm run lint`
- `npm run type-check`
- `npm run build`