### PR TITLE
fix: support focusing viewlets after render

### DIFF
--- a/packages/renderer-process/src/parts/CommandMap/CommandMap.ts
+++ b/packages/renderer-process/src/parts/CommandMap/CommandMap.ts
@@ -102,6 +102,7 @@ export const commandMap = {
   'Viewlet.focus': Viewlet.focus,
   'Viewlet.focusElementByName': Viewlet.focusElementByName,
   'Viewlet.focusSelector': Viewlet.focusSelector,
+  'Viewlet.focusSelectorAfterRender': Viewlet.focusSelectorAfterRender,
   'Viewlet.getDragData': Viewlet.getDragData,
   'Viewlet.handleError': Viewlet.handleError,
   'Viewlet.invoke': Viewlet.invoke,

--- a/packages/renderer-process/src/parts/EditorOnlyViewlet/EditorOnlyViewlet.ts
+++ b/packages/renderer-process/src/parts/EditorOnlyViewlet/EditorOnlyViewlet.ts
@@ -34,6 +34,14 @@ const focusSelector = (uid: number, selector: string): void => {
   element?.focus()
 }
 
+const focusSelectorAfterRender = (uid: number, selector: string): void => {
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      focusSelector(uid, selector)
+    })
+  })
+}
+
 const setBounds = (uid: number, left: number, top: number, width: number, height: number): void => {
   const element = getElement(uid)
   element.style.left = `${left}px`
@@ -83,6 +91,7 @@ const setValueByName = (uid: number, name: string, value: string): void => {
 const commandHandlers: Record<string, (...args: any[]) => unknown> = {
   'Viewlet.dispose': dispose,
   'Viewlet.focusSelector': focusSelector,
+  'Viewlet.focusSelectorAfterRender': focusSelectorAfterRender,
   'Viewlet.setAdditionalFocus': ignoreCommand,
   'Viewlet.setBounds': setBounds,
   'Viewlet.setCss': Css.addCssStyleSheet,

--- a/packages/renderer-process/src/parts/Viewlet/Viewlet.ts
+++ b/packages/renderer-process/src/parts/Viewlet/Viewlet.ts
@@ -213,6 +213,14 @@ export const focusSelector = (viewletId, selector) => {
   }
 }
 
+export const focusSelectorAfterRender = (viewletId, selector) => {
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      focusSelector(viewletId, selector)
+    })
+  })
+}
+
 /**
  * @deprecated
  */
@@ -615,6 +623,7 @@ const commandHandlers = {
   'Viewlet.focus': focus,
   'Viewlet.focusElementByName': focusElementByName,
   'Viewlet.focusSelector': focusSelector,
+  'Viewlet.focusSelectorAfterRender': focusSelectorAfterRender,
   'Viewlet.handleError': handleError,
   'Viewlet.move': move,
   'Viewlet.patchCss': patchCssStyleSheet,

--- a/packages/renderer-process/test/Viewlet.test.ts
+++ b/packages/renderer-process/test/Viewlet.test.ts
@@ -61,6 +61,39 @@ test('appendViewlet applies pending selector focus after mounting child viewlet'
   expect(document.activeElement).toBe(document.querySelector('.EditorInput textarea'))
 })
 
+test('focusSelectorAfterRender focuses after two animation frames', () => {
+  const callbacks: FrameRequestCallback[] = []
+  let viewletState
+  const originalRequestAnimationFrame = globalThis.requestAnimationFrame
+  globalThis.requestAnimationFrame = (callback): number => {
+    callbacks.push(callback)
+    return callbacks.length
+  }
+  ViewletState.state.modules.TestDeferredFocus = {
+    create() {
+      const $Viewlet = document.createElement('div')
+      $Viewlet.innerHTML = '<textarea name="deferred-focus"></textarea>'
+      viewletState = {
+        $Viewlet,
+      }
+      return viewletState
+    },
+  }
+
+  Viewlet.create('TestDeferredFocus')
+  document.body.append(viewletState.$Viewlet)
+  const input = document.querySelector('[name="deferred-focus"]')
+
+  Viewlet.focusSelectorAfterRender('TestDeferredFocus', '[name="deferred-focus"]')
+
+  expect(document.activeElement).toBe(document.body)
+  callbacks.shift()?.(0)
+  expect(document.activeElement).toBe(document.body)
+  callbacks.shift()?.(0)
+  expect(document.activeElement).toBe(input)
+  globalThis.requestAnimationFrame = originalRequestAnimationFrame
+})
+
 test('setDom2 preserves focused input state', () => {
   Object.defineProperty(globalThis, 'CSS', {
     configurable: true,


### PR DESCRIPTION
## Summary
- add a renderer-process command that focuses a viewlet selector after two animation frames
- register the command in full and editor-only render paths
- cover the deferred focus timing

## Tests
- npm test
- npm run type-check
- npm run lint