### PR TITLE
fix: support focusing viewlet roots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3970,9 +3970,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/virtual-dom": {
-      "version": "11.11.4",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/virtual-dom/-/virtual-dom-11.11.4.tgz",
-      "integrity": "sha512-tL9A23DRsRt8DEPDnd5x0DNF4uAZo9rDYi5ifjdyvtKO2bFHsUfcPBN82y1vJJqhGZbOlO1kUm3416+A/FCUYg==",
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/virtual-dom/-/virtual-dom-11.12.0.tgz",
+      "integrity": "sha512-XwDIrNRC4dHViDNhpxprvdW0pLjzY6zfmk/Re1diiMSiKGVNJvfZ9x55ufV63bc+fhAw9RMd4JHeN0QCF+aaEQ==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/web-socket-server": {
@@ -16611,7 +16611,7 @@
       "dependencies": {
         "@lvce-editor/assert": "^1.7.0",
         "@lvce-editor/rpc": "^6.16.0",
-        "@lvce-editor/virtual-dom": "^11.11.4",
+        "@lvce-editor/virtual-dom": "^11.12.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0"
       },

--- a/packages/renderer-process/src/parts/Viewlet/Viewlet.ts
+++ b/packages/renderer-process/src/parts/Viewlet/Viewlet.ts
@@ -199,7 +199,7 @@ export const focusSelector = (viewletId, selector) => {
     return
   }
   const { $Viewlet } = instance.state
-  const $Element = $Viewlet.querySelector(selector)
+  const $Element = $Viewlet.matches(selector) ? $Viewlet : $Viewlet.querySelector(selector)
   if (!$Element) {
     return
   }

--- a/packages/renderer-process/test/Viewlet.test.ts
+++ b/packages/renderer-process/test/Viewlet.test.ts
@@ -61,6 +61,27 @@ test('appendViewlet applies pending selector focus after mounting child viewlet'
   expect(document.activeElement).toBe(document.querySelector('.EditorInput textarea'))
 })
 
+test('focusSelector focuses the viewlet root when it matches the selector', () => {
+  let viewletState
+  ViewletState.state.modules.TestFocusRoot = {
+    create() {
+      const $Viewlet = document.createElement('div')
+      $Viewlet.id = 'TestFocusRoot'
+      $Viewlet.tabIndex = 0
+      viewletState = {
+        $Viewlet,
+      }
+      return viewletState
+    },
+  }
+
+  Viewlet.create('TestFocusRoot')
+  document.body.append(viewletState.$Viewlet)
+  Viewlet.focusSelector('TestFocusRoot', '#TestFocusRoot')
+
+  expect(document.activeElement).toBe(viewletState.$Viewlet)
+})
+
 test('focusSelectorAfterRender focuses after two animation frames', () => {
   const callbacks: FrameRequestCallback[] = []
   let viewletState


### PR DESCRIPTION
## Summary

- allow Viewlet.focusSelector to match the viewlet root itself
- add a jsdom regression test for root focus
- synchronize the root virtual-dom lock entry already updated on main

## Validation

- npm test -- --runInBand
- npm run type-check
- npm run lint
- npm run build
- combined local activity-bar focus and keyboard-navigation e2e scenarios