### PR TITLE
fix: stop WebRTC audio stream

### DIFF
--- a/packages/renderer-process/src/parts/WebRtc/WebRtc.ts
+++ b/packages/renderer-process/src/parts/WebRtc/WebRtc.ts
@@ -18,6 +18,7 @@ interface PcEntry {
   readonly remoteAnalyzer: {
     instance: AnalyserNode | undefined
   }
+  readonly remoteAudio: HTMLAudioElement
 }
 
 const pcs: Record<number, PcEntry> = Object.create(null)
@@ -118,6 +119,7 @@ export const startWebRtcAudioStream = async (options: StartWebRpcAudioStreamOpti
     micStream,
     port,
     remoteAnalyzer: remoteAnalyzerInstance,
+    remoteAudio,
   }
   return offer.sdp
 }
@@ -139,21 +141,22 @@ export const setRemoteDescription = async (options: SetRemoteDescriptionOptions)
 }
 
 // TODO this has a race conditon when start/stop is pressed fast
-export const stopWebRtcAudioStream = async (options: SetRemoteDescriptionOptions) => {
-  const { uid } = options
+export const stopWebRtcAudioStream = async (uid: number) => {
   const pc = pcs[uid]
   if (!pc) {
     return
   }
   // TODO use disposableMap maybe?
-  const { audioCtx, connection, dataChannel, micStream, port } = pc
+  const { audioCtx, connection, dataChannel, micStream, port, remoteAudio } = pc
   delete pcs[uid]
+  connection.ontrack = null
   connection.close()
   dataChannel.close()
   for (const t of micStream.getTracks()) {
     t.stop()
   }
   port.close()
+  remoteAudio.srcObject = null
   if (audioCtx) {
     await audioCtx.close()
   }

--- a/packages/renderer-process/test/WebRtc.test.ts
+++ b/packages/renderer-process/test/WebRtc.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment jsdom
+ */
+import { expect, jest, test } from '@jest/globals'
+import * as WebRtc from '../src/parts/WebRtc/WebRtc.ts'
+
+test('stopWebRtcAudioStream closes the connection and detaches remote audio', async () => {
+  const connectionClose = jest.fn()
+  const dataChannelClose = jest.fn()
+  const micTrackStop = jest.fn()
+  const portClose = jest.fn()
+  const dataChannel = {
+    addEventListener: jest.fn(),
+    close: dataChannelClose,
+    readyState: 'open',
+    send: jest.fn(),
+  }
+  const connection = {
+    addTrack: jest.fn(),
+    close: connectionClose,
+    createDataChannel: jest.fn(() => dataChannel),
+    createOffer: jest.fn(async () => ({ sdp: 'offer' })),
+    ontrack: null as ((event: { readonly streams: readonly MediaStream[] }) => void) | null,
+    setLocalDescription: jest.fn(async () => {}),
+  }
+  Object.defineProperty(globalThis, 'RTCPeerConnection', {
+    configurable: true,
+    value: jest.fn(() => connection),
+  })
+  Object.defineProperty(navigator, 'mediaDevices', {
+    configurable: true,
+    value: {
+      getUserMedia: jest.fn(async () => ({
+        getTracks: () => [{ stop: micTrackStop }],
+      })),
+    },
+  })
+
+  document.body.innerHTML = '<audio class="GptVoiceAudio"></audio>'
+  const remoteAudio = document.querySelector<HTMLAudioElement>('.GptVoiceAudio')!
+  const port = {
+    close: portClose,
+    onmessage: null,
+    postMessage: jest.fn(),
+  } as unknown as MessagePort
+  await WebRtc.startWebRtcAudioStream({
+    elementLocator: '.GptVoiceAudio',
+    ephemeralKey: 'test-key',
+    port,
+    trackAudioData: false,
+    uid: -1,
+  })
+  const remoteStream = {} as MediaStream
+  connection.ontrack?.({ streams: [remoteStream] })
+  expect(remoteAudio.srcObject).toBe(remoteStream)
+
+  await WebRtc.stopWebRtcAudioStream(-1)
+
+  expect(connectionClose).toHaveBeenCalledTimes(1)
+  expect(dataChannelClose).toHaveBeenCalledTimes(1)
+  expect(micTrackStop).toHaveBeenCalledTimes(1)
+  expect(portClose).toHaveBeenCalledTimes(1)
+  expect(remoteAudio.srcObject).toBeNull()
+})


### PR DESCRIPTION
Fix WebRTC stop handling so it closes the active connection and related resources for the requested uid. Detach the remote audio stream during cleanup and cover the full stop lifecycle with a regression test.