### PR TITLE
fix: synchronize workspace dependency cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3558,15 +3558,15 @@
       }
     },
     "node_modules/@lvce-editor/rpc": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.16.0.tgz",
-      "integrity": "sha512-NK9k9/L3fWhwy3j3zrG0ffqHE+9SZ7DevvKcTkrrbgKAS3/L/pAJsTI9MuD8F+18oJEncjCmFTr26+CK3aPSgA==",
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.17.0.tgz",
+      "integrity": "sha512-XS2Dh4aJS4b7chSe7vclqr+Nb6NXpzeOVW2NegP8SA0Z6AyuK0/daqi3gK0ObGxWetGFDUFscRu7t5N9Paf+Zg==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
         "@lvce-editor/command": "^2.0.0",
         "@lvce-editor/ipc": "^16.9.0",
-        "@lvce-editor/json-rpc": "^8.4.0",
+        "@lvce-editor/json-rpc": "^8.6.0",
         "@lvce-editor/verror": "^1.7.0"
       }
     },
@@ -3727,9 +3727,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/virtual-dom": {
-      "version": "11.12.1",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/virtual-dom/-/virtual-dom-11.12.1.tgz",
-      "integrity": "sha512-56ZkTvtqdZeUMptEHMI5xYlQZJL2NkE6U0OloWLZ9rMKvj8B9zFpbhc+s6gTdJb09S0plf3yq1qkEx3hE6v8IQ==",
+      "version": "11.12.2",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/virtual-dom/-/virtual-dom-11.12.2.tgz",
+      "integrity": "sha512-BvE9v9hL78JuPuDScwEclapqLm2VCbD6FPb9yd953PTqx7wTYQirnu7ongqjMKpeI3xthllCJ3QKiv7tW0RUhQ==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/web-socket-server": {
@@ -15654,8 +15654,8 @@
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.9.0",
-        "@lvce-editor/rpc": "^6.16.0",
-        "@lvce-editor/virtual-dom": "^11.12.1",
+        "@lvce-editor/rpc": "^6.17.0",
+        "@lvce-editor/virtual-dom": "^11.12.2",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0"
       },

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -6,6 +6,9 @@
   "keywords": [],
   "author": "",
   "license": "MIT",
+  "scripts": {
+    "test": "node --test"
+  },
   "devDependencies": {
     "@babel/preset-typescript": "^7.29.7",
     "@lvce-editor/verror": "^1.7.0",

--- a/packages/build/src/computeNodeModulesCacheKey.js
+++ b/packages/build/src/computeNodeModulesCacheKey.js
@@ -1,17 +1,12 @@
 import { createHash } from 'node:crypto'
+import { readdirSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
+import { getNodeModulesCacheLocations } from './getNodeModulesCacheLocations.js'
 import { root } from './root.js'
 
-const locations = [
-  'package.json',
-  'package-lock.json',
-  '.github/workflows/pr.yml',
-  '.github/workflows/ci.yml',
-  '.github/workflows/release.yml',
-  'packages/build/src/computeNodeModulesCacheKey.js',
-  'packages/server/src/postinstall.js',
-]
+const packageNames = readdirSync(join(root, 'packages'))
+const locations = getNodeModulesCacheLocations(packageNames)
 
 const getAbsolutePath = (relativePath) => {
   return join(root, relativePath)

--- a/packages/build/src/getNodeModulesCacheLocations.js
+++ b/packages/build/src/getNodeModulesCacheLocations.js
@@ -1,0 +1,14 @@
+export const getNodeModulesCacheLocations = (packageNames) => {
+  const workspacePackageLocations = packageNames.toSorted().map((packageName) => `packages/${packageName}/package.json`)
+  return [
+    'package.json',
+    'package-lock.json',
+    ...workspacePackageLocations,
+    '.github/workflows/pr.yml',
+    '.github/workflows/ci.yml',
+    '.github/workflows/release.yml',
+    'packages/build/src/computeNodeModulesCacheKey.js',
+    'packages/build/src/getNodeModulesCacheLocations.js',
+    'packages/server/src/postinstall.js',
+  ]
+}

--- a/packages/build/test/getNodeModulesCacheLocations.test.js
+++ b/packages/build/test/getNodeModulesCacheLocations.test.js
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { getNodeModulesCacheLocations } from '../src/getNodeModulesCacheLocations.js'
+
+test('includes every workspace package manifest', () => {
+  const locations = getNodeModulesCacheLocations(['server', 'build'])
+
+  assert.deepEqual(locations, [
+    'package.json',
+    'package-lock.json',
+    'packages/build/package.json',
+    'packages/server/package.json',
+    '.github/workflows/pr.yml',
+    '.github/workflows/ci.yml',
+    '.github/workflows/release.yml',
+    'packages/build/src/computeNodeModulesCacheKey.js',
+    'packages/build/src/getNodeModulesCacheLocations.js',
+    'packages/server/src/postinstall.js',
+  ])
+})


### PR DESCRIPTION
Synchronize the root workspace lockfile with the renderer package dependencies.

Include every workspace package manifest in the node_modules cache fingerprint so dependency updates cannot reuse stale installs.