### PR TITLE
fix: focus extension views

### DIFF
--- a/packages/renderer-process/src/parts/ViewletExtensionView/ViewletExtensionView.ts
+++ b/packages/renderer-process/src/parts/ViewletExtensionView/ViewletExtensionView.ts
@@ -4,6 +4,10 @@ import * as SetIframeCsp from '../SetIframeCsp/SetIframeCsp.ts'
 import * as SetIframeSandBox from '../SetIframeSandBox/SetIframeSandBox.ts'
 import * as SetIframeSrc from '../SetIframeSrc/SetIframeSrc.ts'
 
+export const focus = (state): void => {
+  state.$Viewlet.focus()
+}
+
 export const setIframe = (state, src, sandbox = [], srcDoc = '', csp = '', credentialless = true, title = '') => {
   if (!src && !srcDoc) {
     return

--- a/packages/renderer-process/test/ViewletExtensionView.test.ts
+++ b/packages/renderer-process/test/ViewletExtensionView.test.ts
@@ -1,0 +1,15 @@
+/**
+ * @jest-environment jsdom
+ */
+import { expect, test } from '@jest/globals'
+import * as ViewletExtensionView from '../src/parts/ViewletExtensionView/ViewletExtensionView.ts'
+
+test('focuses the extension view root', () => {
+  const $Viewlet = document.createElement('div')
+  $Viewlet.tabIndex = 0
+  document.body.append($Viewlet)
+
+  ViewletExtensionView.focus({ $Viewlet })
+
+  expect(document.activeElement).toBe($Viewlet)
+})


### PR DESCRIPTION
Focus the extension view root when the workbench activates it, so keyboard-enabled virtual DOM previews can receive input immediately after opening.

Add a regression test for focusable extension roots.