### PR TITLE
feature: queue direct viewlet render commands

### DIFF
--- a/packages/renderer-process/src/parts/CommandMap/CommandMap.ts
+++ b/packages/renderer-process/src/parts/CommandMap/CommandMap.ts
@@ -108,6 +108,7 @@ export const commandMap = {
   'Viewlet.handleError': Viewlet.handleError,
   'Viewlet.invoke': Viewlet.invoke,
   'Viewlet.loadModule': Viewlet.loadModule,
+  'Viewlet.queueCommands': Viewlet.queueCommands,
   'Viewlet.refresh': Viewlet.refresh,
   'Viewlet.registerEventListeners': Viewlet.registerEventListeners,
   'Viewlet.removeKeyBindings': Viewlet.removeKeyBindings,

--- a/packages/renderer-process/src/parts/HandleMessagePort/HandleMessagePort.ts
+++ b/packages/renderer-process/src/parts/HandleMessagePort/HandleMessagePort.ts
@@ -1,8 +1,11 @@
 import { PlainMessagePortRpcParent } from '@lvce-editor/rpc'
+import * as Viewlet from '../Viewlet/Viewlet.ts'
 
 export const handleMessagePort = async (port: MessagePort) => {
   await PlainMessagePortRpcParent.create({
-    commandMap: {},
+    commandMap: {
+      'Viewlet.queueCommands': Viewlet.queueCommands,
+    },
     messagePort: port,
   })
 }

--- a/packages/renderer-process/src/parts/PendingViewletCommands/PendingViewletCommands.ts
+++ b/packages/renderer-process/src/parts/PendingViewletCommands/PendingViewletCommands.ts
@@ -1,0 +1,27 @@
+interface PendingViewletCommandBatch {
+  readonly commands: readonly (readonly unknown[])[]
+  readonly uid: number
+}
+
+const pendingBatches = new Map<number, PendingViewletCommandBatch>()
+const state = {
+  nextTransactionId: 1,
+}
+
+export const queue = (uid: number, commands: readonly (readonly unknown[])[]): number => {
+  const transactionId = state.nextTransactionId++
+  pendingBatches.set(transactionId, { commands, uid })
+  return transactionId
+}
+
+export const take = (uid: number, transactionId: number): readonly (readonly unknown[])[] => {
+  const batch = pendingBatches.get(transactionId)
+  if (!batch) {
+    throw new Error(`pending viewlet command transaction not found: ${transactionId}`)
+  }
+  if (batch.uid !== uid) {
+    throw new Error(`pending viewlet command transaction ${transactionId} belongs to ${batch.uid}, not ${uid}`)
+  }
+  pendingBatches.delete(transactionId)
+  return batch.commands
+}

--- a/packages/renderer-process/src/parts/Viewlet/Viewlet.ts
+++ b/packages/renderer-process/src/parts/Viewlet/Viewlet.ts
@@ -8,6 +8,7 @@ import * as DomEventType from '../DomEventType/DomEventType.ts'
 import * as DragInfo from '../DragInfo/DragInfo.ts'
 import * as KeyBindings from '../KeyBindings/KeyBindings.ts'
 import * as Logger from '../Logger/Logger.ts'
+import * as PendingViewletCommands from '../PendingViewletCommands/PendingViewletCommands.ts'
 import * as Promises from '../Promises/Promises.ts'
 import * as RememberFocus from '../RememberFocus/RememberFocus.ts'
 import * as SetBounds from '../SetBounds/SetBounds.ts'
@@ -374,6 +375,14 @@ export const sendMultiple = (commands) => {
   executeCommands(commands)
 }
 
+export const queueCommands = (uid: number, commands: readonly (readonly unknown[])[]): number => {
+  return PendingViewletCommands.queue(uid, commands)
+}
+
+export const commitPending = (uid: number, transactionId: number): void => {
+  executeCommands(PendingViewletCommands.take(uid, transactionId))
+}
+
 export const dispose = (id) => {
   try {
     Assert.number(id)
@@ -616,6 +625,7 @@ const commandHandlers = {
   'Viewlet.appendViewlet': appendViewlet,
   'Viewlet.ariaAnnounce': ariaAnnounce,
   'Viewlet.attachWindowEvents': attachWindowEvents,
+  'Viewlet.commitPending': commitPending,
   'Viewlet.create': create,
   'Viewlet.createFunctionalRoot': createFunctionalRoot,
   'Viewlet.createPlaceholder': createPlaceholder,

--- a/packages/renderer-process/test/Viewlet.test.ts
+++ b/packages/renderer-process/test/Viewlet.test.ts
@@ -189,3 +189,26 @@ test('getDragData returns the latest registered drag data', () => {
 
   expect(Viewlet.getDragData()).toBe(dragData)
 })
+
+test('sendMultiple commits queued viewlet commands at the marker position', () => {
+  const uid = 202
+  const dom = [
+    {
+      childCount: 0,
+      className: 'DirectRenderContent',
+      text: 'ready',
+      type: VirtualDomElements.Div,
+    },
+  ]
+  const transactionId = Viewlet.queueCommands(uid, [['Viewlet.setDom2', uid, dom]])
+
+  expect(document.querySelector('.DirectRenderContent')).toBeNull()
+
+  Viewlet.sendMultiple([
+    ['Viewlet.createFunctionalRoot', 'TestDirectRender', uid, true],
+    ['Viewlet.commitPending', uid, transactionId],
+    ['Viewlet.appendToBody', uid],
+  ])
+
+  expect(document.querySelector('.DirectRenderContent')).not.toBeNull()
+})


### PR DESCRIPTION
Add transactional pending viewlet command batches so direct-render workers can queue DOM work and commit it at the renderer-worker-controlled position in Viewlet.sendMultiple.