### PR TITLE
fix: preserve native button key activation

### DIFF
--- a/packages/renderer-process/src/parts/KeyBindingsEvents/KeyBindingsEvents.ts
+++ b/packages/renderer-process/src/parts/KeyBindingsEvents/KeyBindingsEvents.ts
@@ -8,7 +8,18 @@ const handleMatchingKeyBinding = (identifier) => {
   RendererWorker.send(/* KeyBindings.handleKeyBinding */ 'KeyBindings.handleKeyBinding', /* keyBinding */ identifier)
 }
 
+const isNativeButtonActivation = (event): boolean => {
+  const { altKey, ctrlKey, key, metaKey, shiftKey, target } = event
+  if (altKey || ctrlKey || metaKey || shiftKey) {
+    return false
+  }
+  return target instanceof HTMLButtonElement && (key === 'Enter' || key === ' ')
+}
+
 export const handleKeyDown = (event) => {
+  if (isNativeButtonActivation(event)) {
+    return
+  }
   const identifier = GetKeyBindingIdentifier.getKeyBindingIdentifier(event)
   const identifiers = KeyBindingsState.getIdentifiers()
   const matchingKeyBinding = IsMatchingKeyBinding.isMatchingKeyBinding(identifiers, identifier)

--- a/packages/renderer-process/test/KeyBindings.test.ts
+++ b/packages/renderer-process/test/KeyBindings.test.ts
@@ -108,3 +108,52 @@ test('addKeyBindings - dispatch event with space key', () => {
   )
   expect(RendererWorker.send).toHaveBeenCalledWith('KeyBindings.handleKeyBinding', KeyCode.Space)
 })
+
+test('addKeyBindings - preserves native button activation with enter key', () => {
+  KeyBindings.setIdentifiers(new Uint32Array([KeyCode.Enter]))
+  const button = document.createElement('button')
+  const event = new KeyboardEvent('keydown', {
+    bubbles: true,
+    cancelable: true,
+    key: 'Enter',
+  })
+  button.addEventListener('keydown', KeyBindingsEvents.handleKeyDown)
+
+  button.dispatchEvent(event)
+
+  expect(event.defaultPrevented).toBe(false)
+  expect(RendererWorker.send).not.toHaveBeenCalled()
+})
+
+test('addKeyBindings - preserves native button activation with space key', () => {
+  KeyBindings.setIdentifiers(new Uint32Array([KeyCode.Space]))
+  const button = document.createElement('button')
+  const event = new KeyboardEvent('keydown', {
+    bubbles: true,
+    cancelable: true,
+    key: ' ',
+  })
+  button.addEventListener('keydown', KeyBindingsEvents.handleKeyDown)
+
+  button.dispatchEvent(event)
+
+  expect(event.defaultPrevented).toBe(false)
+  expect(RendererWorker.send).not.toHaveBeenCalled()
+})
+
+test('addKeyBindings - handles modified enter key on native button', () => {
+  KeyBindings.setIdentifiers(new Uint32Array([KeyModifier.CtrlCmd | KeyCode.Enter]))
+  const button = document.createElement('button')
+  const event = new KeyboardEvent('keydown', {
+    bubbles: true,
+    cancelable: true,
+    ctrlKey: true,
+    key: 'Enter',
+  })
+  button.addEventListener('keydown', KeyBindingsEvents.handleKeyDown)
+
+  button.dispatchEvent(event)
+
+  expect(event.defaultPrevented).toBe(true)
+  expect(RendererWorker.send).toHaveBeenCalledWith('KeyBindings.handleKeyBinding', KeyModifier.CtrlCmd | KeyCode.Enter)
+})


### PR DESCRIPTION
Preserve the browser's native Enter and Space activation for unmodified button key presses while keeping modified shortcuts and non-button keybindings routed through LVCE.