### PR TITLE
fix: close title bar menu on click outside

### DIFF
--- a/packages/renderer-process/src/parts/ViewletTitleBarMenuBar/ViewletTitleBarMenuBarEvents.ts
+++ b/packages/renderer-process/src/parts/ViewletTitleBarMenuBar/ViewletTitleBarMenuBarEvents.ts
@@ -13,11 +13,8 @@ const isInsideTitleBarMenu = ($Element) => {
 }
 
 export const handleFocusOut = (event) => {
-  const { relatedTarget, target } = event
+  const { relatedTarget } = event
   if (relatedTarget && isInsideTitleBarMenu(relatedTarget)) {
-    return
-  }
-  if (target && isInsideTitleBarMenu(target)) {
     return
   }
   const uid = ComponentUid.fromEvent(event)

--- a/packages/renderer-process/test/ViewletTitleBarMenuBarEvents.test.ts
+++ b/packages/renderer-process/test/ViewletTitleBarMenuBarEvents.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/ComponentUid/ComponentUid.ts', () => ({
+  fromEvent: jest.fn(() => 7),
+}))
+
+jest.unstable_mockModule('../src/parts/ViewletTitleBarMenuBar/ViewletTitleBarMenuBarFunctions.ts', () => ({
+  closeMenu: jest.fn(),
+}))
+
+const ViewletTitleBarMenuBarEvents = await import('../src/parts/ViewletTitleBarMenuBar/ViewletTitleBarMenuBarEvents.ts')
+const ViewletTitleBarMenuBarFunctions = await import('../src/parts/ViewletTitleBarMenuBar/ViewletTitleBarMenuBarFunctions.ts')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('handleFocusOut closes menu when focus moves outside', () => {
+  const target = document.createElement('div')
+  target.className = 'Menu'
+  const relatedTarget = document.createElement('textarea')
+  relatedTarget.className = 'EditorInput'
+
+  ViewletTitleBarMenuBarEvents.handleFocusOut({ relatedTarget, target })
+
+  expect(ViewletTitleBarMenuBarFunctions.closeMenu).toHaveBeenCalledTimes(1)
+  expect(ViewletTitleBarMenuBarFunctions.closeMenu).toHaveBeenCalledWith(7)
+})
+
+test('handleFocusOut keeps menu open when focus moves within menu', () => {
+  const target = document.createElement('div')
+  target.className = 'Menu'
+  const relatedTarget = document.createElement('button')
+  relatedTarget.className = 'MenuItem'
+
+  ViewletTitleBarMenuBarEvents.handleFocusOut({ relatedTarget, target })
+
+  expect(ViewletTitleBarMenuBarFunctions.closeMenu).not.toHaveBeenCalled()
+})
+
+test('handleFocusOut closes menu when focus is lost', () => {
+  const target = document.createElement('div')
+  target.className = 'Menu'
+
+  ViewletTitleBarMenuBarEvents.handleFocusOut({ relatedTarget: null, target })
+
+  expect(ViewletTitleBarMenuBarFunctions.closeMenu).toHaveBeenCalledTimes(1)
+  expect(ViewletTitleBarMenuBarFunctions.closeMenu).toHaveBeenCalledWith(7)
+})


### PR DESCRIPTION
Closes the title-bar menu when focus moves outside it while preserving focus transitions within menu elements. Adds focused regression coverage for outside, inside, and lost-focus cases.