### PR TITLE
fix: preserve title bar menu component id

### DIFF
--- a/packages/renderer-process/src/parts/OldMenu/Menu.ts
+++ b/packages/renderer-process/src/parts/OldMenu/Menu.ts
@@ -1,6 +1,7 @@
 import * as AriaBoolean from '../AriaBoolean/AriaBoolean.ts'
 import * as AriaRoles from '../AriaRoles/AriaRoles.ts'
 import * as BackDrop from '../BackDrop/BackDrop.ts'
+import * as ComponentUid from '../ComponentUid/ComponentUid.ts'
 import * as DomAttributeType from '../DomAttributeType/DomAttributeType.ts'
 import * as DomEventType from '../DomEventType/DomEventType.ts'
 import * as Event from '../Event/Event.ts'
@@ -266,6 +267,11 @@ export const hideSubmenu = (level) => {
 // TODO support nested menus / submenus
 export const showControlled = ({ $Parent, handleFocusOut, handleKeyDown, height, items, level, width, x, y }) => {
   showMenu(x, y, width, height, items, level)
+  const $Menu = state.$$Menus.at(-1)
+  if ($Parent && $Menu) {
+    const uid = ComponentUid.get($Parent)
+    ComponentUid.set($Menu, uid)
+  }
   // TODO menu should not necessarily know about parent (titleBarMenuBar)
   // it should be the other way around
   // @ts-expect-error

--- a/packages/renderer-process/test/Menu.test.ts
+++ b/packages/renderer-process/test/Menu.test.ts
@@ -5,6 +5,7 @@
 
 import { beforeEach, expect, jest, test } from '@jest/globals'
 import * as AriaBoolean from '../src/parts/AriaBoolean/AriaBoolean.ts'
+import * as ComponentUid from '../src/parts/ComponentUid/ComponentUid.ts'
 import * as DomAttributeType from '../src/parts/DomAttributeType/DomAttributeType.ts'
 import * as MenuItemFlags from '../src/parts/MenuItemFlags/MenuItemFlags.ts'
 import * as WhenExpression from '../src/parts/WhenExpression/WhenExpression.ts'
@@ -36,6 +37,26 @@ const getTextContent = ($Node) => {
 const getSimpleList = ($Menu) => {
   return Array.from($Menu.children, getTextContent)
 }
+
+test('showControlled assigns parent component uid to menu', () => {
+  const parent = document.createElement('div')
+  ComponentUid.set(parent, 7)
+
+  Menu.showControlled({
+    $Parent: parent,
+    handleFocusOut() {},
+    handleKeyDown() {},
+    height: 100,
+    items: [],
+    level: 1,
+    width: 100,
+    x: 0,
+    y: 0,
+  })
+
+  expect(Menu.state.$$Menus).toHaveLength(1)
+  expect(ComponentUid.get(Menu.state.$$Menus[0])).toBe(7)
+})
 
 test.skip('showControlled', () => {
   Menu.showControlled({


### PR DESCRIPTION
## Summary

- assign controlled popup menus the component id of their owning title bar
- ensure focus-out commands target the correct title-bar viewlet
- add regression coverage for popup component ownership

## Testing

- npm test --workspace=packages/renderer-process -- --runInBand --coverage=false Menu.test.ts ViewletTitleBarMenuBarEvents.test.ts