### PR TITLE
fix: listen for title bar menu focus out

### DIFF
--- a/packages/renderer-process/src/parts/ViewletTitleBarMenuBar/ViewletTitleBarMenuBar.ts
+++ b/packages/renderer-process/src/parts/ViewletTitleBarMenuBar/ViewletTitleBarMenuBar.ts
@@ -3,6 +3,7 @@ import * as AriaRoles from '../AriaRoles/AriaRoles.ts'
 import * as Assert from '../Assert/Assert.ts'
 import * as ComponentUid from '../ComponentUid/ComponentUid.ts'
 import * as DomAttributeType from '../DomAttributeType/DomAttributeType.ts'
+import * as DomEventType from '../DomEventType/DomEventType.ts'
 import * as Menu from '../OldMenu/Menu.ts'
 import * as SetBounds from '../SetBounds/SetBounds.ts'
 import * as VirtualDom from '../VirtualDom/VirtualDom.ts'
@@ -138,6 +139,7 @@ const create$Menu = () => {
   $Menu.className = 'Menu'
   $Menu.role = AriaRoles.Menu
   $Menu.tabIndex = -1
+  $Menu.addEventListener(DomEventType.FocusOut, ViewletTitleBarMenuBarEvents.handleFocusOut)
   // $ContextMenu.onmousedown = contextMenuHandleMouseDown
   // TODO mousedown vs click? (click is usually better but mousedown is faster, why wait 100ms?)
   // $Menu.addEventListener('mousedown', handleMouseDown)
@@ -151,7 +153,6 @@ const create$Menu = () => {
   //   passive: true,
   // })
   // $Menu.onkeydown = handleKeyDown
-  // $Menu.addEventListener('focusout', handleFocusOut)
   // $Menu.oncontextmenu = handleContextMenu
   // $ContextMenu.onfocus = handleFocus
   // $ContextMenu.onblur = handleBlur

--- a/packages/renderer-process/test/ViewletTitleBarMenuBar.test.ts
+++ b/packages/renderer-process/test/ViewletTitleBarMenuBar.test.ts
@@ -1,0 +1,42 @@
+/**
+ * @jest-environment jsdom
+ */
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import * as Widget from '../src/parts/Widget/Widget.ts'
+
+jest.unstable_mockModule('../src/parts/ViewletTitleBarMenuBar/ViewletTitleBarMenuBarFunctions.ts', () => ({
+  closeMenu: jest.fn(),
+}))
+
+const ViewletTitleBarMenuBar = await import('../src/parts/ViewletTitleBarMenuBar/ViewletTitleBarMenuBar.ts')
+const ViewletTitleBarMenuBarFunctions = await import('../src/parts/ViewletTitleBarMenuBar/ViewletTitleBarMenuBarFunctions.ts')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  document.body.innerHTML = ''
+  Widget.state.$Widgets = undefined
+  Widget.state.widgetSet = new Set()
+})
+
+test('setMenus closes menu when focus moves outside', () => {
+  const state = {
+    $$Menus: [],
+  }
+  const menu = {
+    focusedIndex: -1,
+    height: 100,
+    level: 0,
+    width: 100,
+    x: 0,
+    y: 0,
+  }
+
+  ViewletTitleBarMenuBar.setMenus(state, [['addMenu', menu, []]], 7)
+
+  const $Menu = state.$$Menus[0]
+  const relatedTarget = document.createElement('textarea')
+  $Menu.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget }))
+
+  expect(ViewletTitleBarMenuBarFunctions.closeMenu).toHaveBeenCalledTimes(1)
+  expect(ViewletTitleBarMenuBarFunctions.closeMenu).toHaveBeenCalledWith(7)
+})

--- a/packages/renderer-process/test/ViewletTitleBarMenuBar.test.ts
+++ b/packages/renderer-process/test/ViewletTitleBarMenuBar.test.ts
@@ -13,7 +13,7 @@ const ViewletTitleBarMenuBarFunctions = await import('../src/parts/ViewletTitleB
 
 beforeEach(() => {
   jest.clearAllMocks()
-  document.body.innerHTML = ''
+  document.body.replaceChildren()
   Widget.state.$Widgets = undefined
   Widget.state.widgetSet = new Set()
 })

--- a/packages/renderer-process/test/ViewletTitleBarMenuBar.test.ts
+++ b/packages/renderer-process/test/ViewletTitleBarMenuBar.test.ts
@@ -19,7 +19,7 @@ beforeEach(() => {
 })
 
 test('setMenus closes menu when focus moves outside', () => {
-  const state = {
+  const state: { $$Menus: HTMLElement[] } = {
     $$Menus: [],
   }
   const menu = {


### PR DESCRIPTION
## Summary

- attach the focus-out listener to directly rendered title-bar popup menus
- route focus leaving the menu through the existing close handler
- add DOM-level regression coverage for the active menu rendering path

## Testing

- npm test --workspace=packages/renderer-process -- --runInBand --coverage=false ViewletTitleBarMenuBar.test.ts ViewletTitleBarMenuBarEvents.test.ts Menu.test.ts