### PR TITLE
fix: keep title bar menu open during rerender

### DIFF
--- a/packages/renderer-process/src/parts/ViewletTitleBarMenuBar/ViewletTitleBarMenuBarEvents.ts
+++ b/packages/renderer-process/src/parts/ViewletTitleBarMenuBar/ViewletTitleBarMenuBarEvents.ts
@@ -13,8 +13,11 @@ const isInsideTitleBarMenu = ($Element) => {
 }
 
 export const handleFocusOut = (event) => {
-  const { relatedTarget } = event
+  const { relatedTarget, target } = event
   if (relatedTarget && isInsideTitleBarMenu(relatedTarget)) {
+    return
+  }
+  if (!relatedTarget && target && !target.isConnected && isInsideTitleBarMenu(target)) {
     return
   }
   const uid = ComponentUid.fromEvent(event)

--- a/packages/renderer-process/test/ViewletTitleBarMenuBarEvents.test.ts
+++ b/packages/renderer-process/test/ViewletTitleBarMenuBarEvents.test.ts
@@ -16,6 +16,7 @@ const ViewletTitleBarMenuBarFunctions = await import('../src/parts/ViewletTitleB
 
 beforeEach(() => {
   jest.clearAllMocks()
+  document.body.replaceChildren()
 })
 
 test('handleFocusOut closes menu when focus moves outside', () => {
@@ -44,9 +45,20 @@ test('handleFocusOut keeps menu open when focus moves within menu', () => {
 test('handleFocusOut closes menu when focus is lost', () => {
   const target = document.createElement('div')
   target.className = 'Menu'
+  document.body.append(target)
 
   ViewletTitleBarMenuBarEvents.handleFocusOut({ relatedTarget: null, target })
 
   expect(ViewletTitleBarMenuBarFunctions.closeMenu).toHaveBeenCalledTimes(1)
   expect(ViewletTitleBarMenuBarFunctions.closeMenu).toHaveBeenCalledWith(7)
+})
+
+test('handleFocusOut keeps menu open when a focused menu item is replaced', () => {
+  const target = document.createElement('button')
+  target.className = 'MenuItem'
+
+  ViewletTitleBarMenuBarEvents.handleFocusOut({ relatedTarget: null, target })
+
+  expect(target.isConnected).toBe(false)
+  expect(ViewletTitleBarMenuBarFunctions.closeMenu).not.toHaveBeenCalled()
 })


### PR DESCRIPTION
Keep title-bar dropdowns open when their focused menu item is replaced during a render, while preserving real focus-out dismissal.