### PR TITLE
fix: activate title bar menus with keyboard

### DIFF
--- a/packages/renderer-process/src/parts/KeyBindingsEvents/KeyBindingsEvents.ts
+++ b/packages/renderer-process/src/parts/KeyBindingsEvents/KeyBindingsEvents.ts
@@ -1,3 +1,4 @@
+import * as AriaRoles from '../AriaRoles/AriaRoles.ts'
 import * as Event from '../Event/Event.ts'
 import * as GetKeyBindingIdentifier from '../GetKeyBindingIdentifier/GetKeyBindingIdentifier.ts'
 import * as IsMatchingKeyBinding from '../IsMatchingKeyBinding/IsMatchingKeyBinding.ts'
@@ -13,7 +14,7 @@ const isNativeButtonActivation = (event): boolean => {
   if (altKey || ctrlKey || metaKey || shiftKey) {
     return false
   }
-  return target instanceof HTMLButtonElement && (key === 'Enter' || key === ' ')
+  return target instanceof HTMLButtonElement && target.role !== AriaRoles.MenuItem && (key === 'Enter' || key === ' ')
 }
 
 export const handleKeyDown = (event) => {

--- a/packages/renderer-process/test/KeyBindings.test.ts
+++ b/packages/renderer-process/test/KeyBindings.test.ts
@@ -141,6 +141,26 @@ test('addKeyBindings - preserves native button activation with space key', () =>
   expect(RendererWorker.send).not.toHaveBeenCalled()
 })
 
+test.each([
+  ['enter', 'Enter', KeyCode.Enter],
+  ['space', ' ', KeyCode.Space],
+])('addKeyBindings - handles %s key on menuitem button', (name, key, keyCode) => {
+  KeyBindings.setIdentifiers(new Uint32Array([keyCode]))
+  const button = document.createElement('button')
+  button.role = 'menuitem'
+  const event = new KeyboardEvent('keydown', {
+    bubbles: true,
+    cancelable: true,
+    key,
+  })
+  button.addEventListener('keydown', KeyBindingsEvents.handleKeyDown)
+
+  button.dispatchEvent(event)
+
+  expect(event.defaultPrevented).toBe(true)
+  expect(RendererWorker.send).toHaveBeenCalledWith('KeyBindings.handleKeyBinding', keyCode)
+})
+
 test('addKeyBindings - handles modified enter key on native button', () => {
   KeyBindings.setIdentifiers(new Uint32Array([KeyModifier.CtrlCmd | KeyCode.Enter]))
   const button = document.createElement('button')


### PR DESCRIPTION
## Summary
- keep `role=menuitem` buttons on the managed keybinding path for Enter and Space
- preserve native activation for ordinary buttons
- cover both title-bar activation keys with regression tests

## Validation
- focused KeyBindings tests
- full test suite
- build
- lint
- type-check