### PR TITLE
fix: defer title bar menu focus loss check

### DIFF
--- a/packages/renderer-process/src/parts/ViewletTitleBarMenuBar/ViewletTitleBarMenuBarEvents.ts
+++ b/packages/renderer-process/src/parts/ViewletTitleBarMenuBar/ViewletTitleBarMenuBarEvents.ts
@@ -17,10 +17,15 @@ export const handleFocusOut = (event) => {
   if (relatedTarget && isInsideTitleBarMenu(relatedTarget)) {
     return
   }
-  if (!relatedTarget && target && !target.isConnected && isInsideTitleBarMenu(target)) {
+  const uid = ComponentUid.fromEvent(event)
+  if (!relatedTarget && target && isInsideTitleBarMenu(target)) {
+    queueMicrotask(() => {
+      if (target.isConnected) {
+        ViewletTitleBarMenuBarFunctions.closeMenu(uid)
+      }
+    })
     return
   }
-  const uid = ComponentUid.fromEvent(event)
   ViewletTitleBarMenuBarFunctions.closeMenu(uid)
 }
 

--- a/packages/renderer-process/test/ViewletTitleBarMenuBarEvents.test.ts
+++ b/packages/renderer-process/test/ViewletTitleBarMenuBarEvents.test.ts
@@ -42,12 +42,13 @@ test('handleFocusOut keeps menu open when focus moves within menu', () => {
   expect(ViewletTitleBarMenuBarFunctions.closeMenu).not.toHaveBeenCalled()
 })
 
-test('handleFocusOut closes menu when focus is lost', () => {
+test('handleFocusOut closes menu when focus is lost', async () => {
   const target = document.createElement('div')
   target.className = 'Menu'
   document.body.append(target)
 
   ViewletTitleBarMenuBarEvents.handleFocusOut({ relatedTarget: null, target })
+  await Promise.resolve()
 
   expect(ViewletTitleBarMenuBarFunctions.closeMenu).toHaveBeenCalledTimes(1)
   expect(ViewletTitleBarMenuBarFunctions.closeMenu).toHaveBeenCalledWith(7)
@@ -58,6 +59,19 @@ test('handleFocusOut keeps menu open when a focused menu item is replaced', () =
   target.className = 'MenuItem'
 
   ViewletTitleBarMenuBarEvents.handleFocusOut({ relatedTarget: null, target })
+
+  expect(target.isConnected).toBe(false)
+  expect(ViewletTitleBarMenuBarFunctions.closeMenu).not.toHaveBeenCalled()
+})
+
+test('handleFocusOut keeps menu open when a focused menu item is replaced after focusout', async () => {
+  const target = document.createElement('button')
+  target.className = 'MenuItem'
+  document.body.append(target)
+
+  ViewletTitleBarMenuBarEvents.handleFocusOut({ relatedTarget: null, target })
+  target.remove()
+  await Promise.resolve()
 
   expect(target.isConnected).toBe(false)
   expect(ViewletTitleBarMenuBarFunctions.closeMenu).not.toHaveBeenCalled()


### PR DESCRIPTION
## Summary

- defer null-related-target title-bar focus loss handling by one microtask
- keep a menu open when its focused row is detached by the renderer immediately after `focusout`
- preserve menu dismissal when the original focused node remains connected

## Root cause

Official LVCE v0.101.15 acceptance showed Chromium dispatches `focusout` while the old focused menu row is still connected. The renderer detaches it in the following microtask, so the synchronous `isConnected` check from #783 ran too early.

## Validation

- new real-timing regression test failed before the production change and passes afterward
- full test suite: 70 suites, 228 tests passed (5 suites / 53 tests skipped)
- build passed
- lint passed
- type-check passed

The existing build warnings for unresolved `addKeyBindings` and `removeKeyBindings` are unchanged and outside this path.