### PR TITLE
feature: route view events directly to workers

### DIFF
--- a/packages/renderer-process/src/parts/DirectViewRpcRegistry/DirectViewRpcRegistry.ts
+++ b/packages/renderer-process/src/parts/DirectViewRpcRegistry/DirectViewRpcRegistry.ts
@@ -1,0 +1,37 @@
+import type { Rpc } from '@lvce-editor/rpc'
+
+const rpcs = new Map<string, Rpc>()
+const viewRpcIds = new Map<number, string>()
+
+export const clear = (): void => {
+  for (const rpc of rpcs.values()) {
+    rpc.dispose()
+  }
+  rpcs.clear()
+  viewRpcIds.clear()
+}
+
+export const get = (uid: number): Rpc | undefined => {
+  const rpcId = viewRpcIds.get(uid)
+  return rpcId === undefined ? undefined : rpcs.get(rpcId)
+}
+
+export const registerRpc = (rpcId: string, rpc: Rpc): void => {
+  const previous = rpcs.get(rpcId)
+  if (previous && previous !== rpc) {
+    previous.dispose()
+  }
+  rpcs.set(rpcId, rpc)
+}
+
+export const registerView = (uid: number, rpcId: string | undefined): void => {
+  if (rpcId === undefined) {
+    viewRpcIds.delete(uid)
+    return
+  }
+  viewRpcIds.set(uid, rpcId)
+}
+
+export const unregisterView = (uid: number): void => {
+  viewRpcIds.delete(uid)
+}

--- a/packages/renderer-process/src/parts/HandleMessagePort/HandleMessagePort.ts
+++ b/packages/renderer-process/src/parts/HandleMessagePort/HandleMessagePort.ts
@@ -1,11 +1,15 @@
 import { PlainMessagePortRpcParent } from '@lvce-editor/rpc'
+import * as DirectViewRpcRegistry from '../DirectViewRpcRegistry/DirectViewRpcRegistry.ts'
 import * as Viewlet from '../Viewlet/Viewlet.ts'
 
-export const handleMessagePort = async (port: MessagePort) => {
-  await PlainMessagePortRpcParent.create({
+export const handleMessagePort = async (port: MessagePort, rpcId?: string): Promise<void> => {
+  const rpc = await PlainMessagePortRpcParent.create({
     commandMap: {
       'Viewlet.queueCommands': Viewlet.queueCommands,
     },
     messagePort: port,
   })
+  if (rpcId !== undefined) {
+    DirectViewRpcRegistry.registerRpc(rpcId, rpc)
+  }
 }

--- a/packages/renderer-process/src/parts/Main/Main.ts
+++ b/packages/renderer-process/src/parts/Main/Main.ts
@@ -2,7 +2,6 @@ import { commandMap } from '../CommandMap/CommandMap.ts'
 import { commandMapRef } from '../CommandMapRef/CommandMapRef.ts'
 import * as ErrorHandling from '../ErrorHandling/ErrorHandling.ts'
 import * as LaunchWorkers from '../LaunchWorkers/LaunchWorkers.ts'
-import * as RendererWorker from '../RendererWorker/RendererWorker.ts'
 import * as RendererWorkerTrace from '../RendererWorkerTrace/RendererWorkerTrace.ts'
 import * as Result from '../Result/Result.ts'
 import * as ViewletColorPicker from '../ViewletColorPicker/ViewletColorPicker.ts'
@@ -15,6 +14,7 @@ import * as ViewletEditorSourceActions from '../ViewletEditorSourceActions/Viewl
 import * as ViewletFindWidget from '../ViewletFindWidget/ViewletFindWidget.ts'
 import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.ts'
 import * as ViewletState from '../ViewletState/ViewletState.ts'
+import * as ViewletEventRouter from '../ViewletEventRouter/ViewletEventRouter.ts'
 import * as ViewletTitleBar from '../ViewletTitleBar/ViewletTitleBar.ts'
 import * as VirtualDom from '../VirtualDom/VirtualDom.ts'
 import * as WindowListeners from '../WindowListeners/WindowListeners.ts'
@@ -38,5 +38,5 @@ export const main = async () => {
     await ErrorHandling.handleError(launchWorkersResult.error, true)
     return
   }
-  VirtualDom.setIpc(RendererWorker)
+  VirtualDom.setIpc(ViewletEventRouter)
 }

--- a/packages/renderer-process/src/parts/Viewlet/Viewlet.ts
+++ b/packages/renderer-process/src/parts/Viewlet/Viewlet.ts
@@ -5,6 +5,7 @@ import * as AttachEvents from '../AttachEvents/AttachEvents.ts'
 import * as ComponentUid from '../ComponentUid/ComponentUid.ts'
 import { addCssStyleSheet, patchCssStyleSheet, removeCssStyleSheet } from '../Css/Css.ts'
 import * as DomEventType from '../DomEventType/DomEventType.ts'
+import * as DirectViewRpcRegistry from '../DirectViewRpcRegistry/DirectViewRpcRegistry.ts'
 import * as DragInfo from '../DragInfo/DragInfo.ts'
 import * as KeyBindings from '../KeyBindings/KeyBindings.ts'
 import * as Logger from '../Logger/Logger.ts'
@@ -42,7 +43,7 @@ export const create = (id, uid = id) => {
   })
 }
 
-export const createFunctionalRoot = (id, uid = id, hasFunctionalEvents) => {
+export const createFunctionalRoot = (id, uid = id, hasFunctionalEvents, directEventRpcId?: string) => {
   let module = state.modules[id]
   if (hasFunctionalEvents) {
     module ||= {}
@@ -56,6 +57,7 @@ export const createFunctionalRoot = (id, uid = id, hasFunctionalEvents) => {
   }
   const instanceState = { $Viewlet: document.createElement('div') }
   ComponentUid.set(instanceState.$Viewlet, uid)
+  DirectViewRpcRegistry.registerView(uid, directEventRpcId)
   setViewletInstance(uid, {
     factory: module,
     state: instanceState,
@@ -387,6 +389,7 @@ export const commitPending = (uid: number, transactionId: number): void => {
 export const dispose = (id) => {
   try {
     Assert.number(id)
+    DirectViewRpcRegistry.unregisterView(id)
     const instance = getViewletInstance(id)
     if (!instance) {
       Logger.warn(`viewlet instance ${id} not found and cannot be disposed`)

--- a/packages/renderer-process/src/parts/ViewletEventRouter/ViewletEventRouter.ts
+++ b/packages/renderer-process/src/parts/ViewletEventRouter/ViewletEventRouter.ts
@@ -1,0 +1,15 @@
+import * as DirectViewRpcRegistry from '../DirectViewRpcRegistry/DirectViewRpcRegistry.ts'
+import * as RendererWorker from '../RendererWorker/RendererWorker.ts'
+
+const executeViewletCommand = 'Viewlet.executeViewletCommand'
+
+export const send = (method: string, uid: number, ...args: readonly any[]): void => {
+  if (method === executeViewletCommand) {
+    const rpc = DirectViewRpcRegistry.get(uid)
+    if (rpc) {
+      rpc.send(method, uid, ...args)
+      return
+    }
+  }
+  RendererWorker.send(method, uid, ...args)
+}

--- a/packages/renderer-process/test/DirectViewRpcRegistry.test.ts
+++ b/packages/renderer-process/test/DirectViewRpcRegistry.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import type { Rpc } from '@lvce-editor/rpc'
+import * as DirectViewRpcRegistry from '../src/parts/DirectViewRpcRegistry/DirectViewRpcRegistry.ts'
+
+const createRpc = (): Rpc =>
+  ({
+    dispose: jest.fn(),
+  }) as unknown as Rpc
+
+beforeEach(() => {
+  DirectViewRpcRegistry.clear()
+})
+
+test('gets the rpc registered for a view', () => {
+  const rpc = createRpc()
+  DirectViewRpcRegistry.registerRpc('Panel', rpc)
+  DirectViewRpcRegistry.registerView(42, 'Panel')
+
+  expect(DirectViewRpcRegistry.get(42)).toBe(rpc)
+})
+
+test('removes a view route', () => {
+  const rpc = createRpc()
+  DirectViewRpcRegistry.registerRpc('Panel', rpc)
+  DirectViewRpcRegistry.registerView(42, 'Panel')
+
+  DirectViewRpcRegistry.unregisterView(42)
+
+  expect(DirectViewRpcRegistry.get(42)).toBeUndefined()
+})
+
+test('disposes a replaced rpc', () => {
+  const previous = createRpc()
+  const replacement = createRpc()
+  DirectViewRpcRegistry.registerRpc('Panel', previous)
+
+  DirectViewRpcRegistry.registerRpc('Panel', replacement)
+
+  expect(previous.dispose).toHaveBeenCalledTimes(1)
+})

--- a/packages/renderer-process/test/Viewlet.test.ts
+++ b/packages/renderer-process/test/Viewlet.test.ts
@@ -4,12 +4,14 @@
 import { beforeEach, expect, test } from '@jest/globals'
 import { VirtualDomElements } from '@lvce-editor/virtual-dom'
 import * as ComponentUid from '../src/parts/ComponentUid/ComponentUid.ts'
+import * as DirectViewRpcRegistry from '../src/parts/DirectViewRpcRegistry/DirectViewRpcRegistry.ts'
 import * as Layout from '../src/parts/Layout/Layout.ts'
 import * as Viewlet from '../src/parts/Viewlet/Viewlet.ts'
 import * as ViewletState from '../src/parts/ViewletState/ViewletState.ts'
 
 beforeEach(() => {
   document.body.replaceChildren()
+  DirectViewRpcRegistry.clear()
 })
 
 test.skip('appendViewlet', async () => {
@@ -189,6 +191,17 @@ test('getDragData returns the latest registered drag data', () => {
   Viewlet.executeCommands([['Viewlet.setDragData', 42, dragData]])
 
   expect(Viewlet.getDragData()).toBe(dragData)
+})
+
+test('createFunctionalRoot registers and dispose removes its direct worker route', () => {
+  const rpc = { dispose() {} }
+  DirectViewRpcRegistry.registerRpc('Panel', rpc as never)
+
+  Viewlet.createFunctionalRoot('TestPanel', 101, true, 'Panel')
+
+  expect(DirectViewRpcRegistry.get(101)).toBe(rpc)
+  Viewlet.dispose(101)
+  expect(DirectViewRpcRegistry.get(101)).toBeUndefined()
 })
 
 test('sendMultiple commits queued viewlet commands at the marker position', () => {

--- a/packages/renderer-process/test/ViewletEventRouter.test.ts
+++ b/packages/renderer-process/test/ViewletEventRouter.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import type { Rpc } from '@lvce-editor/rpc'
+
+const rendererWorkerSend = jest.fn()
+
+jest.unstable_mockModule('../src/parts/RendererWorker/RendererWorker.ts', () => ({
+  send: rendererWorkerSend,
+}))
+
+const DirectViewRpcRegistry = await import('../src/parts/DirectViewRpcRegistry/DirectViewRpcRegistry.ts')
+const ViewletEventRouter = await import('../src/parts/ViewletEventRouter/ViewletEventRouter.ts')
+
+const createRpc = (): Rpc =>
+  ({
+    dispose: jest.fn(),
+    send: jest.fn(),
+  }) as unknown as Rpc
+
+beforeEach(() => {
+  DirectViewRpcRegistry.clear()
+  rendererWorkerSend.mockClear()
+})
+
+test('routes a viewlet event directly to its worker', () => {
+  const rpc = createRpc()
+  DirectViewRpcRegistry.registerRpc('Panel', rpc)
+  DirectViewRpcRegistry.registerView(42, 'Panel')
+
+  ViewletEventRouter.send('Viewlet.executeViewletCommand', 42, 'handleClick', 3)
+
+  expect(rpc.send).toHaveBeenCalledWith('Viewlet.executeViewletCommand', 42, 'handleClick', 3)
+  expect(rendererWorkerSend).not.toHaveBeenCalled()
+})
+
+test('routes an event without a direct worker to the renderer worker', () => {
+  ViewletEventRouter.send('Viewlet.executeViewletCommand', 42, 'handleClick', 3)
+
+  expect(rendererWorkerSend).toHaveBeenCalledWith('Viewlet.executeViewletCommand', 42, 'handleClick', 3)
+})
+
+test('routes other renderer messages to the renderer worker', () => {
+  const rpc = createRpc()
+  DirectViewRpcRegistry.registerRpc('Panel', rpc)
+  DirectViewRpcRegistry.registerView(42, 'Panel')
+
+  ViewletEventRouter.send('Other.command', 42, 'value')
+
+  expect(rendererWorkerSend).toHaveBeenCalledWith('Other.command', 42, 'value')
+  expect(rpc.send).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
## Summary

- register direct worker RPCs and associate functional view roots by component UID
- route virtual-DOM view events directly to the owning worker
- preserve renderer-worker fallback for views without a direct route
- remove view routes during disposal and replace stale worker RPCs safely

## Tests

- npm test -- --runInBand
- npm run type-check
- npm run lint