### PR TITLE
fix: route imperative view events directly

### DIFF
--- a/packages/renderer-process/src/parts/ExecuteViewletCommand/ExecuteViewletCommand.ts
+++ b/packages/renderer-process/src/parts/ExecuteViewletCommand/ExecuteViewletCommand.ts
@@ -1,7 +1,7 @@
 import * as Assert from '../Assert/Assert.ts'
-import * as RendererWorker from '../RendererWorker/RendererWorker.ts'
+import * as ViewletEventRouter from '../ViewletEventRouter/ViewletEventRouter.ts'
 
 export const executeViewletCommand = (uid, command, ...args) => {
   Assert.number(uid)
-  RendererWorker.send('Viewlet.executeViewletCommand', uid, command, ...args)
+  ViewletEventRouter.send('Viewlet.executeViewletCommand', uid, command, ...args)
 }

--- a/packages/renderer-process/test/ExecuteViewletCommand.test.ts
+++ b/packages/renderer-process/test/ExecuteViewletCommand.test.ts
@@ -1,0 +1,15 @@
+import { expect, jest, test } from '@jest/globals'
+
+const send = jest.fn()
+
+jest.unstable_mockModule('../src/parts/ViewletEventRouter/ViewletEventRouter.ts', () => ({
+  send,
+}))
+
+const ExecuteViewletCommand = await import('../src/parts/ExecuteViewletCommand/ExecuteViewletCommand.ts')
+
+test('routes the command through the viewlet event router', () => {
+  ExecuteViewletCommand.executeViewletCommand(42, 'handleMenuClick', 0, 14)
+
+  expect(send).toHaveBeenCalledWith('Viewlet.executeViewletCommand', 42, 'handleMenuClick', 0, 14)
+})


### PR DESCRIPTION
## Summary
- route renderer-process imperative view commands through the UID-aware view event router
- preserve renderer-worker fallback for unmapped views
- add regression coverage for title-bar menu command routing

## Testing
- npm test
- npm run type-check
- npm run lint