### PR TITLE
feature: forward direct worker commands to renderer worker

### DIFF
--- a/packages/renderer-process/src/parts/HandleMessagePort/HandleMessagePort.ts
+++ b/packages/renderer-process/src/parts/HandleMessagePort/HandleMessagePort.ts
@@ -1,10 +1,16 @@
 import { PlainMessagePortRpcParent } from '@lvce-editor/rpc'
 import * as DirectViewRpcRegistry from '../DirectViewRpcRegistry/DirectViewRpcRegistry.ts'
+import * as RendererWorker from '../RendererWorker/RendererWorker.ts'
 import * as Viewlet from '../Viewlet/Viewlet.ts'
+
+const forwardRendererWorkerCommand = (method: string, ...params: readonly unknown[]): void => {
+  RendererWorker.send(method, ...params)
+}
 
 export const handleMessagePort = async (port: MessagePort, rpcId?: string): Promise<void> => {
   const rpc = await PlainMessagePortRpcParent.create({
     commandMap: {
+      'Viewlet.forwardRendererWorkerCommand': forwardRendererWorkerCommand,
       'Viewlet.queueCommands': Viewlet.queueCommands,
     },
     messagePort: port,

--- a/packages/renderer-process/test/HandleMessagePort.test.ts
+++ b/packages/renderer-process/test/HandleMessagePort.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, expect, jest, test } from '@jest/globals'
+import { PlainMessagePortRpc } from '@lvce-editor/rpc'
+
+const rendererWorkerSend = jest.fn()
+
+jest.unstable_mockModule('../src/parts/RendererWorker/RendererWorker.ts', () => ({
+  send: rendererWorkerSend,
+}))
+
+const DirectViewRpcRegistry = await import('../src/parts/DirectViewRpcRegistry/DirectViewRpcRegistry.ts')
+const { handleMessagePort } = await import('../src/parts/HandleMessagePort/HandleMessagePort.ts')
+
+afterEach(() => {
+  DirectViewRpcRegistry.clear()
+  rendererWorkerSend.mockClear()
+})
+
+test('forwards a direct worker command to the renderer worker', async () => {
+  const { port1, port2 } = new MessageChannel()
+  const directWorkerRpc = await PlainMessagePortRpc.create({
+    commandMap: {},
+    messagePort: port1,
+  })
+  await handleMessagePort(port2, 'Panel')
+
+  await directWorkerRpc.invoke('Viewlet.forwardRendererWorkerCommand', 'Layout.maximizePanel', 42)
+
+  expect(rendererWorkerSend).toHaveBeenCalledWith('Layout.maximizePanel', 42)
+  await directWorkerRpc.dispose()
+})


### PR DESCRIPTION
Adds a direct-port command that forwards one-way messages to renderer-worker. This lets a directly connected view finish its event RPC before renderer-worker runs layout work that can call back into that view.