### PR TITLE
fix: preserve terminal focus during mount

### DIFF
--- a/packages/renderer-process/src/parts/ViewletTerminal2/ViewletTerminal2.ts
+++ b/packages/renderer-process/src/parts/ViewletTerminal2/ViewletTerminal2.ts
@@ -58,6 +58,10 @@ const mountTerminal = async (state, uid) => {
   state.disposables = [inputDisposable, resizeDisposable]
   fitAddon.fit()
   flushPendingData(state)
+  if (state.pendingFocus) {
+    state.pendingFocus = false
+    terminal.focus()
+  }
 }
 
 export const create = () => {
@@ -71,6 +75,7 @@ export const create = () => {
     mountPromise: undefined,
     mouseDownListener: undefined,
     pendingData: [],
+    pendingFocus: false,
     resizeObserver: undefined,
     terminal: undefined,
   }
@@ -101,8 +106,10 @@ export const focus = (state) => {
   Assert.object(state)
   const { terminal } = state
   if (!terminal) {
+    state.pendingFocus = true
     return
   }
+  state.pendingFocus = false
   terminal.focus()
 }
 
@@ -131,6 +138,7 @@ export const dispose = (state) => {
   }
   state.disposables = []
   state.pendingData.length = 0
+  state.pendingFocus = false
   state.resizeObserver?.disconnect()
   state.resizeObserver = undefined
   state.terminal?.dispose()

--- a/packages/renderer-process/test/ViewletTerminal2.test.ts
+++ b/packages/renderer-process/test/ViewletTerminal2.test.ts
@@ -130,6 +130,7 @@ test('create', () => {
   const state = ViewletTerminal2.create()
   expect(state.$Viewlet.className).toBe('Viewlet Terminal XtermTerminal')
   expect(state.pendingData).toEqual([])
+  expect(state.pendingFocus).toBe(false)
   expect(state.terminal).toBeUndefined()
 })
 
@@ -160,6 +161,16 @@ test('setTerminal only mounts once while xterm is loading', async () => {
   const state = ViewletTerminal2.create()
   await Promise.all([ViewletTerminal2.setTerminal(state, 1), ViewletTerminal2.setTerminal(state, 1)])
   expect(terminalInstances).toHaveLength(1)
+})
+
+test('focus requested while xterm is mounting is applied after mount', async () => {
+  const state = ViewletTerminal2.create()
+  const mountPromise = ViewletTerminal2.setTerminal(state, 1)
+
+  ViewletTerminal2.focus(state)
+  await mountPromise
+
+  expect(terminalInstances[0].focused).toBe(true)
 })
 
 test('forwards xterm input and resize events', async () => {


### PR DESCRIPTION
Preserve a terminal focus request made while xterm is still mounting, then apply it as soon as the terminal is ready. Adds regression coverage for the async mount ordering.