### PR TITLE
feature: expose direct view uids

### DIFF
--- a/packages/renderer-process/src/parts/CommandMap/CommandMap.ts
+++ b/packages/renderer-process/src/parts/CommandMap/CommandMap.ts
@@ -3,6 +3,7 @@ import * as Clipboard_ from '../ClipBoard/ClipBoard.ts'
 import * as ConfirmPrompt from '../ConfirmPrompt/ConfirmPrompt.ts'
 import * as Css from '../Css/Css.ts'
 import * as Developer from '../Developer/Developer.ts'
+import * as DirectViewRpcRegistry from '../DirectViewRpcRegistry/DirectViewRpcRegistry.ts'
 import * as Download from '../Download/Download.ts'
 import * as FileHandles from '../FileHandles/FileHandles.ts'
 import * as FilePicker from '../FilePicker/FilePicker.ts'
@@ -46,6 +47,7 @@ export const commandMap = {
   'Css.addCssStyleSheet': Css.addCssStyleSheet,
   'Css.getSelectionText': Css.getSelectionText,
   'Developer.showState': Developer.showState,
+  'DirectView.getUid': DirectViewRpcRegistry.getViewUid,
   'Download.downloadFile': Download.downloadFile,
   'FileHandles.get': FileHandles.get,
   'FilePicker.showDirectoryPicker': FilePicker.showDirectoryPicker,

--- a/packages/renderer-process/src/parts/DirectViewRpcRegistry/DirectViewRpcRegistry.ts
+++ b/packages/renderer-process/src/parts/DirectViewRpcRegistry/DirectViewRpcRegistry.ts
@@ -16,6 +16,19 @@ export const get = (uid: number): Rpc | undefined => {
   return rpcId === undefined ? undefined : rpcs.get(rpcId)
 }
 
+export const getViewUid = (rpcId: string): number => {
+  let matchingUid: number | undefined
+  for (const [uid, registeredRpcId] of viewRpcIds) {
+    if (registeredRpcId === rpcId) {
+      matchingUid = uid
+    }
+  }
+  if (matchingUid === undefined) {
+    throw new Error(`direct view not found: ${rpcId}`)
+  }
+  return matchingUid
+}
+
 export const registerRpc = (rpcId: string, rpc: Rpc): void => {
   const previous = rpcs.get(rpcId)
   if (previous && previous !== rpc) {

--- a/packages/renderer-process/test/DirectViewRpcRegistry.test.ts
+++ b/packages/renderer-process/test/DirectViewRpcRegistry.test.ts
@@ -17,6 +17,18 @@ test('gets the rpc registered for a view', () => {
   DirectViewRpcRegistry.registerView(42, 'Panel')
 
   expect(DirectViewRpcRegistry.get(42)).toBe(rpc)
+  expect(DirectViewRpcRegistry.getViewUid('Panel')).toBe(42)
+})
+
+test('gets the most recently registered view uid for an rpc', () => {
+  DirectViewRpcRegistry.registerView(42, 'QuickPick')
+  DirectViewRpcRegistry.registerView(43, 'QuickPick')
+
+  expect(DirectViewRpcRegistry.getViewUid('QuickPick')).toBe(43)
+})
+
+test('throws when an rpc has no registered view', () => {
+  expect(() => DirectViewRpcRegistry.getViewUid('Explorer')).toThrow('direct view not found: Explorer')
 })
 
 test('removes a view route', () => {


### PR DESCRIPTION
## Summary
- expose the current direct-render view UID by RPC ID
- prefer the most recently registered matching view
- cover missing and multi-instance lookup behavior

## Tests
- npm run type-check
- focused DirectViewRpcRegistry tests