### PR TITLE
feature: expose focused direct view uid

### DIFF
--- a/packages/renderer-process/src/parts/CommandMap/CommandMap.ts
+++ b/packages/renderer-process/src/parts/CommandMap/CommandMap.ts
@@ -47,6 +47,7 @@ export const commandMap = {
   'Css.addCssStyleSheet': Css.addCssStyleSheet,
   'Css.getSelectionText': Css.getSelectionText,
   'Developer.showState': Developer.showState,
+  'DirectView.getFocusedUid': DirectViewRpcRegistry.getFocusedViewUid,
   'DirectView.getUid': DirectViewRpcRegistry.getViewUid,
   'Download.downloadFile': Download.downloadFile,
   'FileHandles.get': FileHandles.get,

--- a/packages/renderer-process/src/parts/DirectViewRpcRegistry/DirectViewRpcRegistry.ts
+++ b/packages/renderer-process/src/parts/DirectViewRpcRegistry/DirectViewRpcRegistry.ts
@@ -1,4 +1,5 @@
 import type { Rpc } from '@lvce-editor/rpc'
+import * as ComponentUid from '../ComponentUid/ComponentUid.ts'
 
 const rpcs = new Map<string, Rpc>()
 const viewRpcIds = new Map<number, string>()
@@ -27,6 +28,14 @@ export const getViewUid = (rpcId: string): number => {
     throw new Error(`direct view not found: ${rpcId}`)
   }
   return matchingUid
+}
+
+export const getFocusedViewUid = (rpcId: string, element: Element | null = document.activeElement): number => {
+  const uid = element ? ComponentUid.get(element) : 0
+  if (!uid || viewRpcIds.get(uid) !== rpcId) {
+    throw new Error(`focused direct view not found: ${rpcId}`)
+  }
+  return uid
 }
 
 export const registerRpc = (rpcId: string, rpc: Rpc): void => {

--- a/packages/renderer-process/test/DirectViewRpcRegistry.test.ts
+++ b/packages/renderer-process/test/DirectViewRpcRegistry.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 import type { Rpc } from '@lvce-editor/rpc'
+import * as ComponentUid from '../src/parts/ComponentUid/ComponentUid.ts'
 import * as DirectViewRpcRegistry from '../src/parts/DirectViewRpcRegistry/DirectViewRpcRegistry.ts'
 
 const createRpc = (): Rpc =>
@@ -25,6 +26,15 @@ test('gets the most recently registered view uid for an rpc', () => {
   DirectViewRpcRegistry.registerView(43, 'QuickPick')
 
   expect(DirectViewRpcRegistry.getViewUid('QuickPick')).toBe(43)
+})
+
+test('gets the focused view uid for an rpc', () => {
+  const editor = { parentNode: undefined } as unknown as HTMLElement
+  const input = { parentNode: editor } as unknown as HTMLElement
+  ComponentUid.set(editor, 42)
+  DirectViewRpcRegistry.registerView(42, 'Editor')
+
+  expect(DirectViewRpcRegistry.getFocusedViewUid('Editor', input)).toBe(42)
 })
 
 test('throws when an rpc has no registered view', () => {


### PR DESCRIPTION
Resolve a focused DOM node to its registered direct-view UID. This lets the test worker target the intended editor instance directly while preserving the existing registry ownership checks.